### PR TITLE
Privatelink support

### DIFF
--- a/modules/cost/main.tf
+++ b/modules/cost/main.tf
@@ -327,6 +327,7 @@ resource "aws_cur_report_definition" "cur_report_definition" {
   additional_schema_elements = ["RESOURCES"]
   s3_bucket                  = data.aws_s3_bucket.cost_bucket.bucket
   s3_region                  = "us-east-1"
+  s3_prefix                  = var.cur_prefix
 }
 
 resource "streamsec_aws_cost_ack" "this" {

--- a/modules/flow-logs/main.tf
+++ b/modules/flow-logs/main.tf
@@ -247,3 +247,12 @@ resource "aws_s3_bucket_lifecycle_configuration" "flowlogs_bucket_config" {
     status = var.flowlogs_bucket_lifecycle_rule[0].status
   }
 }
+
+################################################################################
+# Private Link
+################################################################################
+resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
+  count      = var.enable_privatelink ? 1 : 0
+  role       = aws_iam_role.lambda_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}

--- a/modules/flow-logs/privatelink.tf
+++ b/modules/flow-logs/privatelink.tf
@@ -1,0 +1,12 @@
+module "privatelink" {
+    source = "../private-link"
+    
+    enable_privatelink              = var.enable_privatelink
+    privatelink_service_name        = var.privatelink_service_name
+    vpc_id                          = var.vpc_id
+    private_subnet_ids              = var.private_subnet_ids
+    privatelink_security_group_id   = var.privatelink_security_group_id
+    enable_privatelink_private_dns  = var.enable_privatelink_private_dns
+    privatelink_tags                = var.privatelink_tags
+    
+}

--- a/modules/flow-logs/privatelink.tf
+++ b/modules/flow-logs/privatelink.tf
@@ -1,12 +1,12 @@
 module "privatelink" {
-    source = "../private-link"
-    
-    enable_privatelink              = var.enable_privatelink
-    privatelink_service_name        = var.privatelink_service_name
-    vpc_id                          = var.vpc_id
-    private_subnet_ids              = var.private_subnet_ids
-    privatelink_security_group_id   = var.privatelink_security_group_id
-    enable_privatelink_private_dns  = var.enable_privatelink_private_dns
-    privatelink_tags                = var.privatelink_tags
-    
+  source = "../private-link"
+
+  enable_privatelink             = var.enable_privatelink
+  privatelink_service_name       = var.privatelink_service_name
+  vpc_id                         = var.vpc_id
+  private_subnet_ids             = var.private_subnet_ids
+  privatelink_security_group_id  = var.privatelink_security_group_id
+  enable_privatelink_private_dns = var.enable_privatelink_private_dns
+  privatelink_tags               = var.privatelink_tags
+
 }

--- a/modules/flow-logs/variables.tf
+++ b/modules/flow-logs/variables.tf
@@ -219,3 +219,49 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+################################################################################
+# Private Link
+################################################################################
+
+variable "enable_privatelink" {
+  description = "Create an Interface VPC Endpoint for StreamSecurity"
+  type        = bool
+  default     = false
+}
+
+variable "privatelink_service_name" {
+  description = "StreamSecurity AWS PrivateLink service name for your region (from StreamSecurity)"
+  type        = string
+  default     = null
+}
+
+variable "vpc_id" {
+  description = "VPC ID where the Interface Endpoint will be created"
+  type        = string
+  default     = null
+}
+
+variable "private_subnet_ids" {
+  description = "Private subnet IDs for the Interface Endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "privatelink_security_group_id" {
+  description = "Optional existing SG ID allowing egress 443 to the endpoint. If null, the module creates one."
+  type        = string
+  default     = null
+}
+
+variable "enable_privatelink_private_dns" {
+  description = "Enable Private DNS on the VPC Endpoint (recommended)"
+  type        = bool
+  default     = true
+}
+
+variable "privatelink_tags" {
+  description = "Tags for PrivateLink resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/private-link/local.tf
+++ b/modules/private-link/local.tf
@@ -1,5 +1,3 @@
 locals {
   _pl_sg_id = var.privatelink_security_group_id != null ? var.privatelink_security_group_id : (var.enable_privatelink ? aws_security_group.streamsec_privatelink[0].id : null)
-
-    streamsec_api_url = (var.enable_privatelink && try(length(var.privatelink_service_name) > 0, false)) ? var.privatelink_service_name : data.streamsec_host.this.url
 }

--- a/modules/private-link/local.tf
+++ b/modules/private-link/local.tf
@@ -1,3 +1,4 @@
 locals {
   _pl_sg_id = var.privatelink_security_group_id != null ? var.privatelink_security_group_id : (var.enable_privatelink ? aws_security_group.streamsec_privatelink[0].id : null)
+  lightlytics_dns = [ for entry in aws_vpc_endpoint.streamsec.dns_entry : entry.dns_name if can(regex("lightlytics\\.com$", entry.dns_name))][0]
 }

--- a/modules/private-link/local.tf
+++ b/modules/private-link/local.tf
@@ -1,4 +1,4 @@
 locals {
-  _pl_sg_id = var.privatelink_security_group_id != null ? var.privatelink_security_group_id : (var.enable_privatelink ? aws_security_group.streamsec_privatelink[0].id : null)
-  lightlytics_dns = [ for entry in aws_vpc_endpoint.streamsec[0].dns_entry : entry.dns_name if can(regex("lightlytics\\.com$", entry.dns_name))][0]
+  _pl_sg_id       = var.privatelink_security_group_id != null ? var.privatelink_security_group_id : (var.enable_privatelink ? aws_security_group.streamsec_privatelink[0].id : null)
+  lightlytics_dns = [for entry in aws_vpc_endpoint.streamsec[0].dns_entry : entry.dns_name if can(regex("lightlytics\\.com$", entry.dns_name))][0]
 }

--- a/modules/private-link/local.tf
+++ b/modules/private-link/local.tf
@@ -1,0 +1,5 @@
+locals {
+  _pl_sg_id = var.privatelink_security_group_id != null ? var.privatelink_security_group_id : (var.enable_privatelink ? aws_security_group.streamsec_privatelink[0].id : null)
+
+    streamsec_api_url = (var.enable_privatelink && try(length(var.privatelink_service_name) > 0, false)) ? var.privatelink_service_name : data.streamsec_host.this.url
+}

--- a/modules/private-link/local.tf
+++ b/modules/private-link/local.tf
@@ -1,4 +1,4 @@
 locals {
   _pl_sg_id = var.privatelink_security_group_id != null ? var.privatelink_security_group_id : (var.enable_privatelink ? aws_security_group.streamsec_privatelink[0].id : null)
-  lightlytics_dns = [ for entry in aws_vpc_endpoint.streamsec.dns_entry : entry.dns_name if can(regex("lightlytics\\.com$", entry.dns_name))][0]
+  lightlytics_dns = [ for entry in aws_vpc_endpoint.streamsec[0].dns_entry : entry.dns_name if can(regex("lightlytics\\.com$", entry.dns_name))][0]
 }

--- a/modules/private-link/main.tf
+++ b/modules/private-link/main.tf
@@ -7,7 +7,15 @@ resource "aws_security_group" "streamsec_privatelink" {
   name_prefix = "streamsec-privatelink-"
   vpc_id      = var.vpc_id
   description = "Allow HTTPS to StreamSecurity PrivateLink endpoint"
-
+  
+  ingress {
+    description = "HTTPS to VPCE ENI targets"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  
   egress {
     description = "HTTPS to VPCE ENI targets"
     from_port   = 443

--- a/modules/private-link/main.tf
+++ b/modules/private-link/main.tf
@@ -7,7 +7,7 @@ resource "aws_security_group" "streamsec_privatelink" {
   name_prefix = "streamsec-privatelink-"
   vpc_id      = var.vpc_id
   description = "Allow HTTPS to StreamSecurity PrivateLink endpoint"
-  
+
   ingress {
     description = "HTTPS to VPCE ENI targets"
     from_port   = 443
@@ -15,7 +15,7 @@ resource "aws_security_group" "streamsec_privatelink" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
-  
+
   egress {
     description = "HTTPS to VPCE ENI targets"
     from_port   = 443

--- a/modules/private-link/main.tf
+++ b/modules/private-link/main.tf
@@ -1,0 +1,35 @@
+################################################################################
+# Private Link
+################################################################################
+
+resource "aws_security_group" "streamsec_privatelink" {
+  count       = var.enable_privatelink && var.privatelink_security_group_id == null ? 1 : 0
+  name_prefix = "streamsec-privatelink-"
+  vpc_id      = var.vpc_id
+  description = "Allow HTTPS to StreamSecurity PrivateLink endpoint"
+
+  egress {
+    description = "HTTPS to VPCE ENI targets"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = var.privatelink_tags
+}
+
+resource "aws_vpc_endpoint" "streamsec" {
+  count               = var.enable_privatelink ? 1 : 0
+  vpc_id              = var.vpc_id
+  service_name        = var.privatelink_service_name
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = var.private_subnet_ids
+  private_dns_enabled = var.enable_privatelink_private_dns
+  security_group_ids  = [local._pl_sg_id]
+
+  tags = merge(
+    { Name = "streamsec-privatelink" },
+    var.privatelink_tags
+  )
+}

--- a/modules/private-link/outputs.tf
+++ b/modules/private-link/outputs.tf
@@ -1,0 +1,18 @@
+################################################################################
+# Private Link
+################################################################################
+
+output "privatelink_vpce_id" {
+  value       = try(aws_vpc_endpoint.streamsec[0].id, null)
+  description = "The Interface VPC Endpoint ID"
+}
+
+output "privatelink_dns_entries" {
+  value       = try(aws_vpc_endpoint.streamsec[0].dns_entry, null)
+  description = "DNS entries for the endpoint (includes the private hosted zone name when private DNS is enabled)"
+}
+
+output "privatelink_security_group_id" {
+  value       = local._pl_sg_id
+  description = "Security Group used for PrivateLink"
+}

--- a/modules/private-link/outputs.tf
+++ b/modules/private-link/outputs.tf
@@ -16,3 +16,9 @@ output "privatelink_security_group_id" {
   value       = local._pl_sg_id
   description = "Security Group used for PrivateLink"
 }
+
+# Output the extracted DNS name
+output "lightlytics_endpoint" {
+  description = "The Lightlytics DNS endpoint for the VPC Endpoint"
+  value       = local.lightlytics_dns
+}

--- a/modules/private-link/variables.tf
+++ b/modules/private-link/variables.tf
@@ -1,0 +1,45 @@
+################################################################################
+# Private Link
+################################################################################
+
+variable "enable_privatelink" {
+  description = "Create an Interface VPC Endpoint for StreamSecurity"
+  type        = bool
+  default     = false
+}
+
+variable "privatelink_service_name" {
+  description = "StreamSecurity AWS PrivateLink service name for your region (from StreamSecurity)"
+  type        = string
+  default     = null
+}
+
+variable "vpc_id" {
+  description = "VPC ID where the Interface Endpoint will be created"
+  type        = string
+  default     = null
+}
+
+variable "private_subnet_ids" {
+  description = "Private subnet IDs for the Interface Endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "privatelink_security_group_id" {
+  description = "Optional existing SG ID allowing egress 443 to the endpoint. If null, the module creates one."
+  type        = string
+  default     = null
+}
+
+variable "enable_privatelink_private_dns" {
+  description = "Enable Private DNS on the VPC Endpoint (recommended)"
+  type        = bool
+  default     = true
+}
+
+variable "privatelink_tags" {
+  description = "Tags for PrivateLink resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/real-time-events/main.tf
+++ b/modules/real-time-events/main.tf
@@ -122,7 +122,7 @@ resource "aws_lambda_function" "streamsec_real_time_events_lambda" {
 
   vpc_config {
     subnet_ids         = var.enable_privatelink && var.private_subnet_ids != null ? var.private_subnet_ids : var.lambda_subnet_ids
-    security_group_ids = var.enable_privatelink && var.privatelink_security_group_id != null ? concat(var.lambda_security_group_ids, [var.privatelink_security_group_id]) : var.lambda_security_group_ids
+    security_group_ids = var.enable_privatelink ? concat(var.lambda_security_group_ids, module.privatelink.privatelink_security_group_id ,[var.privatelink_security_group_id]) : var.lambda_security_group_ids
   }
 
   environment {

--- a/modules/real-time-events/main.tf
+++ b/modules/real-time-events/main.tf
@@ -110,8 +110,8 @@ resource "aws_lambda_function" "streamsec_real_time_events_lambda" {
   layers        = [aws_lambda_layer_version.streamsec_lambda_layer.arn]
 
   vpc_config {
-    subnet_ids         = var.enable_privatelink && var.private_subnet_ids != null ? private_subnet_ids : var.lambda_subnet_ids
-    security_group_ids = var.enable_privatelink && var.privatelink_security_group_id != null ? privatelink_security_group_id : var.lambda_security_group_ids
+    subnet_ids         = var.enable_privatelink && var.private_subnet_ids != null ? var.private_subnet_ids : var.lambda_subnet_ids
+    security_group_ids = var.enable_privatelink && var.privatelink_security_group_id != null ? var.privatelink_security_group_id : var.lambda_security_group_ids
   }
 
   environment {

--- a/modules/real-time-events/main.tf
+++ b/modules/real-time-events/main.tf
@@ -111,7 +111,7 @@ resource "aws_lambda_function" "streamsec_real_time_events_lambda" {
 
   vpc_config {
     subnet_ids         = var.enable_privatelink && var.private_subnet_ids != null ? var.private_subnet_ids : var.lambda_subnet_ids
-    security_group_ids = var.enable_privatelink && var.privatelink_security_group_id != null ? var.privatelink_security_group_id : var.lambda_security_group_ids
+    security_group_ids = var.enable_privatelink && var.privatelink_security_group_id != null ? concat(var.lambda_security_group_ids, [var.privatelink_security_group_id]) : var.lambda_security_group_ids
   }
 
   environment {

--- a/modules/real-time-events/main.tf
+++ b/modules/real-time-events/main.tf
@@ -122,7 +122,7 @@ resource "aws_lambda_function" "streamsec_real_time_events_lambda" {
 
   vpc_config {
     subnet_ids         = var.enable_privatelink && var.private_subnet_ids != null ? var.private_subnet_ids : var.lambda_subnet_ids
-    security_group_ids = var.enable_privatelink ? concat(var.lambda_security_group_ids, module.privatelink.privatelink_security_group_id ,[var.privatelink_security_group_id]) : var.lambda_security_group_ids
+    security_group_ids = var.enable_privatelink ? concat(var.lambda_security_group_ids, [module.privatelink.privatelink_security_group_id] ,[var.privatelink_security_group_id]) : var.lambda_security_group_ids
   }
 
   environment {

--- a/modules/real-time-events/main.tf
+++ b/modules/real-time-events/main.tf
@@ -18,10 +18,10 @@ locals {
   compatible_runtimes = [var.lambda_runtime]
 
   # If the privatelink module/output is null (e.g., disabled or not yet created), fall back to empty list
-  _pl_dns_entries = coalesce(module.privatelink.privatelink_dns_entries, [])
+  _pl_dns_entries = coalesce(module.privatelink.lightlytics_endpoint, [])
 
   # Safely pick first dns_name if present; otherwise null
-  _pl_dns_name = length(local._pl_dns_entries) > 0 ? local._pl_dns_entries[0].dns_name : null
+  _pl_dns_name = length(local._pl_dns_entries) > 0 ? module.privatelink.lightlytics_endpoint : null
 
   # Final API URL: use PrivateLink only when enabled *and* we have a DNS name
   effective_api_url = (

--- a/modules/real-time-events/main.tf
+++ b/modules/real-time-events/main.tf
@@ -18,7 +18,7 @@ locals {
   compatible_runtimes = [var.lambda_runtime]
 
   # If the privatelink module/output is null (e.g., disabled or not yet created), fall back to empty list
-  _pl_dns_entries = coalesce(module.privatelink.lightlytics_endpoint, [])
+  _pl_dns_entries = coalesce(module.privatelink.lightlytics_endpoint, null)
 
   # Safely pick first dns_name if present; otherwise null
   _pl_dns_name = length(local._pl_dns_entries) > 0 ? module.privatelink.lightlytics_endpoint : null

--- a/modules/real-time-events/main.tf
+++ b/modules/real-time-events/main.tf
@@ -122,7 +122,7 @@ resource "aws_lambda_function" "streamsec_real_time_events_lambda" {
 
   vpc_config {
     subnet_ids         = var.enable_privatelink && var.private_subnet_ids != null ? var.private_subnet_ids : var.lambda_subnet_ids
-    security_group_ids = var.enable_privatelink ? concat(var.lambda_security_group_ids, [module.privatelink.privatelink_security_group_id] ,[var.privatelink_security_group_id]) : var.lambda_security_group_ids
+    security_group_ids = var.enable_privatelink ? concat(var.lambda_security_group_ids, [module.privatelink.privatelink_security_group_id]) : var.lambda_security_group_ids
   }
 
   environment {

--- a/modules/real-time-events/main.tf
+++ b/modules/real-time-events/main.tf
@@ -110,14 +110,14 @@ resource "aws_lambda_function" "streamsec_real_time_events_lambda" {
   layers        = [aws_lambda_layer_version.streamsec_lambda_layer.arn]
 
   vpc_config {
-    subnet_ids         = var.lambda_subnet_ids
-    security_group_ids = var.lambda_security_group_ids
+    subnet_ids         = var.enable_privatelink && var.private_subnet_ids != null ? private_subnet_ids : var.lambda_subnet_ids
+    security_group_ids = var.enable_privatelink && var.privatelink_security_group_id != null ? privatelink_security_group_id : var.lambda_security_group_ids
   }
 
   environment {
     variables = {
       SECRET_NAME = aws_secretsmanager_secret.streamsec_collection_secret.name
-      API_URL     = data.streamsec_host.this.url
+      API_URL     = var.enable_privatelink && module.streamsec_account.privatelink_dns_entries[0].dns_name != null ? "https://${module.streamsec_account.privatelink_dns_entries[0].dns_name}" : data.streamsec_host.this.url
       ENV         = "production"
       NODE_ENV    = "production"
     }
@@ -164,4 +164,13 @@ resource "streamsec_aws_real_time_events_ack" "this" {
   cloud_account_id = data.aws_caller_identity.current.account_id
   region           = data.aws_region.current.name
   depends_on       = [aws_lambda_permission.streamsec_allow_lambda_cloudwatch_invocation]
+}
+
+################################################################################
+# Private Link
+################################################################################
+resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
+  count      = var.enable_privatelink ? 1 : 0
+  role       = aws_iam_role.lambda_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }

--- a/modules/real-time-events/main.tf
+++ b/modules/real-time-events/main.tf
@@ -117,7 +117,7 @@ resource "aws_lambda_function" "streamsec_real_time_events_lambda" {
   environment {
     variables = {
       SECRET_NAME = aws_secretsmanager_secret.streamsec_collection_secret.name
-      API_URL     = var.enable_privatelink && module.streamsec_account.privatelink_dns_entries[0].dns_name != null ? "https://${module.streamsec_account.privatelink_dns_entries[0].dns_name}" : data.streamsec_host.this.url
+      API_URL     = var.enable_privatelink && module.privatelink.privatelink_dns_entries[0].dns_name != null ? "https://${module.privatelink.privatelink_dns_entries[0].dns_name}" : data.streamsec_host.this.url
       ENV         = "production"
       NODE_ENV    = "production"
     }

--- a/modules/real-time-events/privatelink.tf
+++ b/modules/real-time-events/privatelink.tf
@@ -1,0 +1,12 @@
+module "privatelink" {
+    source = "../private-link"
+    
+    enable_privatelink              = var.enable_privatelink
+    privatelink_service_name        = var.privatelink_service_name
+    vpc_id                          = var.vpc_id
+    private_subnet_ids              = var.private_subnet_ids
+    privatelink_security_group_id   = var.privatelink_security_group_id
+    enable_privatelink_private_dns  = var.enable_privatelink_private_dns
+    privatelink_tags                = var.privatelink_tags
+    
+}

--- a/modules/real-time-events/privatelink.tf
+++ b/modules/real-time-events/privatelink.tf
@@ -1,12 +1,12 @@
 module "privatelink" {
-    source = "../private-link"
-    
-    enable_privatelink              = var.enable_privatelink
-    privatelink_service_name        = var.privatelink_service_name
-    vpc_id                          = var.vpc_id
-    private_subnet_ids              = var.private_subnet_ids
-    privatelink_security_group_id   = var.privatelink_security_group_id
-    enable_privatelink_private_dns  = var.enable_privatelink_private_dns
-    privatelink_tags                = var.privatelink_tags
-    
+  source = "../private-link"
+
+  enable_privatelink             = var.enable_privatelink
+  privatelink_service_name       = var.privatelink_service_name
+  vpc_id                         = var.vpc_id
+  private_subnet_ids             = var.private_subnet_ids
+  privatelink_security_group_id  = var.privatelink_security_group_id
+  enable_privatelink_private_dns = var.enable_privatelink_private_dns
+  privatelink_tags               = var.privatelink_tags
+
 }

--- a/modules/real-time-events/variables.tf
+++ b/modules/real-time-events/variables.tf
@@ -163,3 +163,49 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+################################################################################
+# Private Link
+################################################################################
+
+variable "enable_privatelink" {
+  description = "Create an Interface VPC Endpoint for StreamSecurity"
+  type        = bool
+  default     = false
+}
+
+variable "privatelink_service_name" {
+  description = "StreamSecurity AWS PrivateLink service name for your region (from StreamSecurity)"
+  type        = string
+  default     = null
+}
+
+variable "vpc_id" {
+  description = "VPC ID where the Interface Endpoint will be created"
+  type        = string
+  default     = null
+}
+
+variable "private_subnet_ids" {
+  description = "Private subnet IDs for the Interface Endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "privatelink_security_group_id" {
+  description = "Optional existing SG ID allowing egress 443 to the endpoint. If null, the module creates one."
+  type        = string
+  default     = null
+}
+
+variable "enable_privatelink_private_dns" {
+  description = "Enable Private DNS on the VPC Endpoint (recommended)"
+  type        = bool
+  default     = true
+}
+
+variable "privatelink_tags" {
+  description = "Tags for PrivateLink resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
Add optional AWS PrivateLink support via Terraform

Adds an opt-in PrivateLink path without changing existing behavior.

New vars: enable_privatelink, privatelink_api_url, privatelink_security_group_id, private_subnet_ids

Lambda: appends PL SG and overrides API_URL only when enabled
