### PR TITLE
feat(real-time): support multiple log groups for centralized collection

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -30,12 +30,12 @@ module "real_time_us_east_1" {
   depends_on = [module.account]
 
   # Optional: Centralized CloudWatch Logs collection
-  # central_cloudtrail_log_group    = "aws-cloudtrail-logs-123456789012"
-  # central_vpc_flow_logs_log_group = "/aws/vpc/flowlogs/my-vpc"
-  # central_vpc_flow_logs_fields    = "version account-id action bytes dstaddr end interface-id log-status packets pkt-dstaddr pkt-srcaddr protocol srcaddr srcport dstport start vpc-id subnet-id instance-id tcp-flags region"
-  # central_eks_audit_log_group     = "/aws/eks/my-cluster/cluster"
-  # central_route53_log_group       = "/staging/route53dnslogs/cw-test"
-  # central_bedrock_log_group       = "/staging/awsbedrocklogs/cw-test"
+  # central_cloudtrail_log_groups    = ["aws-cloudtrail-logs-123456789012"]
+  # central_vpc_flow_logs_log_groups = ["/aws/vpc/flowlogs/my-vpc"]
+  # central_vpc_flow_logs_fields     = "version account-id action bytes dstaddr end interface-id log-status packets pkt-dstaddr pkt-srcaddr protocol srcaddr srcport dstport start vpc-id subnet-id instance-id tcp-flags region"
+  # central_eks_audit_log_groups     = ["/aws/eks/my-cluster/cluster"]
+  # central_route53_log_groups       = ["/staging/route53dnslogs/cw-test"]
+  # central_bedrock_log_groups       = ["/staging/awsbedrocklogs/cw-test"]
   # central_kinesis_stream_arns     = ["arn:aws:kinesis:us-east-1:123456789012:stream/my-stream"]
 }
 

--- a/modules/real-time-events/main.tf
+++ b/modules/real-time-events/main.tf
@@ -7,7 +7,7 @@ data "streamsec_aws_account" "this" {
 
 locals {
   lambda_source_code_bucket = "${var.lambda_source_code_bucket_prefix}-${data.aws_region.current.region}"
-  cloudwatch_rules = { for i in range(length(fileset(path.module, "templates/*.json"))) :
+  cloudwatch_rules = length(var.central_cloudtrail_log_groups) > 0 ? {} : { for i in range(length(fileset(path.module, "templates/*.json"))) :
     "streamsec-rule-${i}" => {
       name          = "${var.cloudwatch_event_rules_prefix}rule-${i}"
       description   = "Cloud Trail for Stream Security real time events Lambda"
@@ -199,14 +199,22 @@ resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
 ################################################################################
 
 locals {
-  central_log_groups = {
-    cloudtrail = var.central_cloudtrail_log_group
-    flowlogs   = var.central_vpc_flow_logs_log_group
-    eksaudit   = var.central_eks_audit_log_group
-    route53    = var.central_route53_log_group
-    bedrock    = var.central_bedrock_log_group
+  central_log_groups_by_type = {
+    cloudtrail = var.central_cloudtrail_log_groups
+    flowlogs   = var.central_vpc_flow_logs_log_groups
+    eksaudit   = var.central_eks_audit_log_groups
+    route53    = var.central_route53_log_groups
+    bedrock    = var.central_bedrock_log_groups
   }
-  active_central_log_groups = { for k, v in local.central_log_groups : k => v if v != "" }
+
+  central_log_subscriptions = merge([
+    for type, groups in local.central_log_groups_by_type : {
+      for lg in groups : "${type}:${lg}" => {
+        type      = type
+        log_group = lg
+      }
+    }
+  ]...)
 
   eks_audit_filter_pattern = <<-EOT
 {(($.sourceIPs[0] != "::1" && $.sourceIPs[0] != "127.0.0.1") || ($.sourceIPs[1] != "::1" && $.sourceIPs[1] != "127.0.0.1")) && $.stage = "ResponseComplete" && $.verb != "watch" && $.user.username != "system:kube*" && $.user.username != "eks:*" && ($.objectRef.resource not exists || ($.objectRef.resource != "events" && $.objectRef.resource != "leases")) && ($.objectRef.subresource not exists || ($.objectRef.subresource != "status" && $.objectRef.subresource != "scale" && $.objectRef.subresource != "proxy" && $.objectRef.subresource != "token" && ($.objectRef.subresource != "binding" || ($.objectRef.subresource = "binding" && $.responseStatus.code != 201))))}
@@ -214,7 +222,7 @@ EOT
 }
 
 resource "aws_lambda_permission" "streamsec_allow_cwlogs_invocation" {
-  count         = length(local.active_central_log_groups) > 0 ? 1 : 0
+  count         = length(local.central_log_subscriptions) > 0 ? 1 : 0
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.streamsec_real_time_events_lambda.function_name
   principal     = "logs.${data.aws_region.current.name}.amazonaws.com"
@@ -222,10 +230,10 @@ resource "aws_lambda_permission" "streamsec_allow_cwlogs_invocation" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "streamsec_central_log_filters" {
-  for_each        = local.active_central_log_groups
-  name            = "streamsec-${each.key}-to-collector"
-  log_group_name  = each.value
-  filter_pattern  = each.key == "eksaudit" ? trimspace(local.eks_audit_filter_pattern) : ""
+  for_each        = local.central_log_subscriptions
+  name            = "streamsec-${each.value.type}-${substr(md5(each.value.log_group), 0, 8)}-to-collector"
+  log_group_name  = each.value.log_group
+  filter_pattern  = each.value.type == "eksaudit" ? trimspace(local.eks_audit_filter_pattern) : ""
   destination_arn = aws_lambda_function.streamsec_real_time_events_lambda.arn
 
   depends_on = [aws_lambda_permission.streamsec_allow_cwlogs_invocation]

--- a/modules/real-time-events/main.tf
+++ b/modules/real-time-events/main.tf
@@ -7,7 +7,7 @@ data "streamsec_aws_account" "this" {
 
 locals {
   lambda_source_code_bucket = "${var.lambda_source_code_bucket_prefix}-${data.aws_region.current.region}"
-  cloudwatch_rules = length(var.central_cloudtrail_log_groups) > 0 ? {} : { for i in range(length(fileset(path.module, "templates/*.json"))) :
+  cloudwatch_rules = (length(var.central_cloudtrail_log_groups) > 0 || length(var.central_kinesis_stream_arns) > 0) ? {} : { for i in range(length(fileset(path.module, "templates/*.json"))) :
     "streamsec-rule-${i}" => {
       name          = "${var.cloudwatch_event_rules_prefix}rule-${i}"
       description   = "Cloud Trail for Stream Security real time events Lambda"

--- a/modules/real-time-events/variables.tf
+++ b/modules/real-time-events/variables.tf
@@ -214,16 +214,16 @@ variable "privatelink_tags" {
 # Centralized CloudWatch Logs Collection
 ################################################################################
 
-variable "central_cloudtrail_log_group" {
-  description = "(Optional) Name of an existing CloudWatch Logs log group containing CloudTrail logs"
-  type        = string
-  default     = ""
+variable "central_cloudtrail_log_groups" {
+  description = "(Optional) List of existing CloudWatch Logs log groups containing CloudTrail logs"
+  type        = list(string)
+  default     = []
 }
 
-variable "central_vpc_flow_logs_log_group" {
-  description = "(Optional) Name of an existing CloudWatch Logs log group containing VPC Flow Logs"
-  type        = string
-  default     = ""
+variable "central_vpc_flow_logs_log_groups" {
+  description = "(Optional) List of existing CloudWatch Logs log groups containing VPC Flow Logs"
+  type        = list(string)
+  default     = []
 }
 
 variable "central_vpc_flow_logs_fields" {
@@ -232,22 +232,22 @@ variable "central_vpc_flow_logs_fields" {
   default     = ""
 }
 
-variable "central_eks_audit_log_group" {
-  description = "(Optional) Name of an existing CloudWatch Logs log group containing EKS audit logs"
-  type        = string
-  default     = ""
+variable "central_eks_audit_log_groups" {
+  description = "(Optional) List of existing CloudWatch Logs log groups containing EKS audit logs"
+  type        = list(string)
+  default     = []
 }
 
-variable "central_route53_log_group" {
-  description = "(Optional) Name of an existing CloudWatch Logs log group containing Route53 DNS query logs"
-  type        = string
-  default     = ""
+variable "central_route53_log_groups" {
+  description = "(Optional) List of existing CloudWatch Logs log groups containing Route53 DNS query logs"
+  type        = list(string)
+  default     = []
 }
 
-variable "central_bedrock_log_group" {
-  description = "(Optional) Name of an existing CloudWatch Logs log group containing Bedrock model invocation logs"
-  type        = string
-  default     = ""
+variable "central_bedrock_log_groups" {
+  description = "(Optional) List of existing CloudWatch Logs log groups containing Bedrock model invocation logs"
+  type        = list(string)
+  default     = []
 }
 
 variable "central_kinesis_stream_arns" {


### PR DESCRIPTION
Updates the module to accept lists of log groups instead of single strings for CloudTrail, VPC Flow Logs, EKS audit, Route53, and Bedrock. This allows the real-time event collector to ingest logs from multiple sources of the same type by dynamically creating subscription filters with unique names.