### PR TITLE
DEV-18926 add optional external_id input

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ No modules.
 | <a name="input_cloudtrail_name"></a> [cloudtrail\_name](#input\_cloudtrail\_name) | Name of the CloudTrail to create | `string` | `"streamsec-real-time-cloudtrail"` | no |
 | <a name="input_cloudtrail_tags"></a> [cloudtrail\_tags](#input\_cloudtrail\_tags) | tags for cloudtrail | `map(string)` | `{}` | no |
 | <a name="input_create_cloudtrail"></a> [create\_cloudtrail](#input\_create\_cloudtrail) | Whether to create a CloudTrail for the AWS account | `bool` | `false` | no |
+| <a name="input_external_id"></a> [external\_id](#input\_external\_id) | Optional pre-shared external ID (8-character uppercase alphanumeric) to use in the IAM role trust policy. If omitted, Stream Security generates one automatically. | `string` | `null` | no |
 | <a name="input_iam_policy_description"></a> [iam\_policy\_description](#input\_iam\_policy\_description) | Description to use on IAM policy created | `string` | `"Stream Security IAM Policy"` | no |
 | <a name="input_iam_policy_name"></a> [iam\_policy\_name](#input\_iam\_policy\_name) | Name to use on IAM policy created | `string` | `"streamsec-policy"` | no |
 | <a name="input_iam_policy_path"></a> [iam\_policy\_path](#input\_iam\_policy\_path) | IAM policy path | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,7 @@ resource "streamsec_aws_account" "this" {
   cloud_account_id = data.aws_caller_identity.current.account_id
   display_name     = var.aws_account_display_name
   cloud_regions    = var.aws_account_regions
+  external_id      = var.external_id
 }
 
 locals {

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,16 @@ variable "aws_account_regions" {
   type        = list(string)
 }
 
+variable "external_id" {
+  description = "Optional pre-shared external ID (8-character uppercase alphanumeric) to use in the IAM role trust policy. If omitted, Stream Security generates one automatically."
+  type        = string
+  default     = null
+  validation {
+    condition     = var.external_id == null || can(regex("^[A-Z0-9]{8}$", var.external_id))
+    error_message = "external_id must be an 8-character uppercase alphanumeric string (A-Z, 0-9)."
+  }
+}
+
 ################################################################################
 # Stream Security IAM Role
 ################################################################################


### PR DESCRIPTION
## Summary
- Adds an optional `external_id` variable (8-char uppercase alphanumeric, validated) that is forwarded to the `streamsec_aws_account` resource.
- When the caller supplies a value, the trust policy of the created IAM role carries that pre-shared value; when unset, Stream Security generates one (current behavior).
- No breaking change — `default = null`, existing consumers are unaffected.

Ticket: [DEV-18926](https://stream-security.atlassian.net/browse/DEV-18926)

## Depends on
- [streamsec-terraform/terraform-provider-streamsec#16](https://github.com/streamsec-terraform/terraform-provider-streamsec/pull/16) — provider must be released with `external_id` as an Optional attribute before this module can pass the value through. Once released, bump `versions.tf` `streamsec` min version accordingly (separate small follow-up commit).

## Test plan
- [ ] Apply existing example with no `external_id` set → confirm plan + apply are byte-identical to pre-change
- [ ] Apply with `external_id = "TESTABCD"` against a staging AWS sandbox → confirm `aws_iam_role.this` assume_role_policy contains `"sts:ExternalId": "TESTABCD"`
- [ ] Confirm the Stream account doc (`accounts` collection in MongoDB) persists `external_id = "TESTABCD"`
- [ ] Trigger a full scan from Stream → verify `sts:AssumeRole` succeeds
- [ ] Validator fires on invalid values (`"abc"`, lowercase, non-alphanumeric)

🤖 Generated with [Claude Code](https://claude.com/claude-code)