### PR TITLE
DEV-17714-add EKS audit logs module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ crash.log
 crash.*.log
 
 local-tests/
+*.zip
 examples/local
 **.terraform
 **.terraform.lock.hcl

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -70,3 +70,21 @@ module "response" {
   source     = "../../modules/response"
   depends_on = [module.account]
 }
+
+module "eks_audit_us_east_1" {
+  source = "../../modules/eks-audit"
+  providers = {
+    aws = aws.aws-east-1
+  }
+  depends_on = [module.account]
+}
+
+module "eks_audit_us_east_2" {
+  source               = "../../modules/eks-audit"
+  resource_prefix      = "acme"
+  eks_exclude_clusters = ["test-cluster"]
+  providers = {
+    aws = aws.aws-east-2
+  }
+  depends_on = [module.account]
+}

--- a/modules/eks-audit/README.md
+++ b/modules/eks-audit/README.md
@@ -1,0 +1,107 @@
+# terraform-streamsec-aws-account/eks-audit
+
+Terraform module for collecting EKS audit logs and forwarding them to Stream Security.
+
+This module auto-discovers EKS clusters in the region, creates CloudWatch Log subscription filters on their audit log groups, and deploys a collector Lambda that forwards the logs to the Stream Security API.
+
+## Usage
+
+```hcl
+# Basic — auto-discover all clusters in the region
+module "eks_audit" {
+  source     = "streamsec-terraform/aws-account//modules/eks-audit"
+  depends_on = [module.account]
+}
+
+# With include/exclude filtering and prefix
+module "eks_audit" {
+  source               = "streamsec-terraform/aws-account//modules/eks-audit"
+  resource_prefix      = "acme"
+  eks_include_clusters = ["prod-cluster", "staging-cluster"]
+  depends_on           = [module.account]
+}
+
+# Multi-region with shared IAM role
+module "eks_audit_us_east_1" {
+  source = "streamsec-terraform/aws-account//modules/eks-audit"
+  providers = {
+    aws = aws.us-east-1
+  }
+  depends_on = [module.account]
+}
+
+module "eks_audit_us_west_2" {
+  source             = "streamsec-terraform/aws-account//modules/eks-audit"
+  collector_role_arn = module.eks_audit_us_east_1.collector_role_arn
+  providers = {
+    aws = aws.us-west-2
+  }
+  depends_on = [module.account]
+}
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_archive"></a> [archive](#requirement\_archive) | >= 2.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
+| <a name="requirement_streamsec"></a> [streamsec](#requirement\_streamsec) | >= 1.7 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_archive"></a> [archive](#provider\_archive) | >= 2.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
+| <a name="provider_streamsec"></a> [streamsec](#provider\_streamsec) | >= 1.7 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_log_group.collector](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_log_subscription_filter.eks_audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_subscription_filter) | resource |
+| [aws_iam_role.collector](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.secrets_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy_attachment.lambda_basic_execution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_lambda_function.collector](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_lambda_permission.allow_cloudwatch_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
+| [aws_secretsmanager_secret.collection_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret_version.collection_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [random_string.suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_eks_clusters.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_clusters) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [streamsec_aws_account.this](https://registry.terraform.io/providers/streamsec-terraform/streamsec/latest/docs/data-sources/aws_account) | data source |
+| [streamsec_host.this](https://registry.terraform.io/providers/streamsec-terraform/streamsec/latest/docs/data-sources/host) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_collection_token_secret_name"></a> [collection\_token\_secret\_name](#input\_collection\_token\_secret\_name) | Base name for the Secrets Manager secret storing the collection token | `string` | `"streamsec-eks-collection-token"` | no |
+| <a name="input_collector_lambda_memory_size"></a> [collector\_lambda\_memory\_size](#input\_collector\_lambda\_memory\_size) | The amount of memory in MB to allocate to the collector Lambda function | `number` | `128` | no |
+| <a name="input_collector_lambda_timeout"></a> [collector\_lambda\_timeout](#input\_collector\_lambda\_timeout) | The amount of time in seconds the collector Lambda function is allowed to run | `number` | `30` | no |
+| <a name="input_collector_role_arn"></a> [collector\_role\_arn](#input\_collector\_role\_arn) | If set, skip IAM role creation and use this existing role ARN for the collector Lambda | `string` | `null` | no |
+| <a name="input_eks_exclude_clusters"></a> [eks\_exclude\_clusters](#input\_eks\_exclude\_clusters) | Skip these EKS clusters from subscription | `list(string)` | `[]` | no |
+| <a name="input_eks_include_clusters"></a> [eks\_include\_clusters](#input\_eks\_include\_clusters) | Only subscribe these EKS clusters. If empty, all clusters in the region are included. | `list(string)` | `[]` | no |
+| <a name="input_lambda_log_retention_days"></a> [lambda\_log\_retention\_days](#input\_lambda\_log\_retention\_days) | The number of days to retain the collector Lambda CloudWatch logs | `number` | `7` | no |
+| <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | Optional prefix prepended before StreamSecurity in all resource names | `string` | `""` | no |
+| <a name="input_secret_recovery_window_days"></a> [secret\_recovery\_window\_days](#input\_secret\_recovery\_window\_days) | Number of days Secrets Manager waits before deleting the secret. Set to 0 for immediate deletion. | `number` | `0` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of global tags to add to all created resources | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_collector_lambda_arn"></a> [collector\_lambda\_arn](#output\_collector\_lambda\_arn) | ARN of the EKS audit collector Lambda function |
+| <a name="output_collector_lambda_name"></a> [collector\_lambda\_name](#output\_collector\_lambda\_name) | Name of the EKS audit collector Lambda function |
+| <a name="output_collector_role_arn"></a> [collector\_role\_arn](#output\_collector\_role\_arn) | ARN of the IAM role used by the collector Lambda |
+| <a name="output_secret_arn"></a> [secret\_arn](#output\_secret\_arn) | ARN of the Secrets Manager secret storing the collection token |
+| <a name="output_subscribed_clusters"></a> [subscribed\_clusters](#output\_subscribed\_clusters) | List of EKS cluster names that have subscription filters |
+<!-- END_TF_DOCS -->

--- a/modules/eks-audit/lambda/index.py
+++ b/modules/eks-audit/lambda/index.py
@@ -1,0 +1,47 @@
+import os
+import urllib3
+import json
+import boto3
+import logging
+
+logger = logging.getLogger("EKS-Audit-Collector")
+logger.setLevel(logging.INFO)
+
+http = urllib3.PoolManager()
+secrets_client = boto3.client('secretsmanager')
+
+_cached_token = None
+
+
+def handler(event, context):
+    if not os.environ.get('FORWARD_URL') or not os.environ.get('SECRET_NAME'):
+        logger.error('Missing FORWARD_URL or SECRET_NAME environment variables')
+        return
+
+    if 'awslogs' not in event or 'data' not in event.get('awslogs', {}):
+        logger.error('Event does not contain awslogs data, skipping')
+        return
+
+    global _cached_token
+    if _cached_token is None:
+        try:
+            secret_response = secrets_client.get_secret_value(SecretId=os.environ['SECRET_NAME'])
+            _cached_token = secret_response['SecretString']
+        except Exception as e:
+            logger.error(f'Failed to retrieve collection token from Secrets Manager: {str(e)}')
+            return
+
+    # payload is base64-encoded gzip -- the API expects it in this form
+    payload = event['awslogs']['data']
+    response = http.request(
+        'POST',
+        f"{os.environ['FORWARD_URL']}/api/v1/collection/eks-audit",
+        body=json.dumps({"logs": payload, "region": os.environ["AWS_REGION"]}),
+        headers={"X-Lightlytics-Token": _cached_token, "Content-Type": "application/json"},
+        retries=2
+    )
+
+    if response.status >= 400:
+        logger.error(f'API returned error status {response.status}')
+    else:
+        logger.info(f'Forwarded {len(payload)} bytes and received response status: {response.status}')

--- a/modules/eks-audit/lambda/index.py
+++ b/modules/eks-audit/lambda/index.py
@@ -33,15 +33,23 @@ def handler(event, context):
 
     # payload is base64-encoded gzip -- the API expects it in this form
     payload = event['awslogs']['data']
-    response = http.request(
-        'POST',
-        f"{os.environ['FORWARD_URL']}/api/v1/collection/eks-audit",
-        body=json.dumps({"logs": payload, "region": os.environ["AWS_REGION"]}),
-        headers={"X-Lightlytics-Token": _cached_token, "Content-Type": "application/json"},
-        retries=2
-    )
+    try:
+        response = http.request(
+            'POST',
+            f"{os.environ['FORWARD_URL']}/api/v1/collection/eks-audit",
+            body=json.dumps({"logs": payload, "region": os.environ["AWS_REGION"]}),
+            headers={"X-Lightlytics-Token": _cached_token, "Content-Type": "application/json"},
+            timeout=urllib3.Timeout(connect=2, read=5),
+            retries=urllib3.util.Retry(total=2, status_forcelist=[500, 502, 503, 504])
+        )
+    except Exception as e:
+        logger.error(f'Failed to forward logs: {str(e)}')
+        return
 
-    if response.status >= 400:
+    if response.status in (401, 403):
+        _cached_token = None
+        logger.error(f'Authentication failed (status {response.status}), token cache cleared')
+    elif response.status >= 400:
         logger.error(f'API returned error status {response.status}')
     else:
-        logger.info(f'Forwarded {len(payload)} bytes and received response status: {response.status}')
+        logger.info(f'Forwarded {len(payload)} bytes with status {response.status}')

--- a/modules/eks-audit/lambda/index.py
+++ b/modules/eks-audit/lambda/index.py
@@ -7,6 +7,7 @@ import logging
 logger = logging.getLogger("EKS-Audit-Collector")
 logger.setLevel(logging.INFO)
 
+# module-level for warm Lambda reuse across invocations
 http = urllib3.PoolManager()
 secrets_client = boto3.client('secretsmanager')
 

--- a/modules/eks-audit/lambda/index.py
+++ b/modules/eks-audit/lambda/index.py
@@ -3,13 +3,14 @@ import urllib3
 import json
 import boto3
 import logging
+from botocore.exceptions import ClientError
 
 logger = logging.getLogger("EKS-Audit-Collector")
 logger.setLevel(logging.INFO)
 
 # module-level for warm Lambda reuse across invocations
 http = urllib3.PoolManager()
-secrets_client = boto3.client('secretsmanager')
+secrets_client = boto3.client('secretsmanager', region_name=os.environ.get('AWS_REGION'))
 
 _cached_token = None
 
@@ -28,7 +29,7 @@ def handler(event, context):
         try:
             secret_response = secrets_client.get_secret_value(SecretId=os.environ['SECRET_NAME'])
             _cached_token = secret_response['SecretString']
-        except Exception as e:
+        except ClientError as e:
             logger.error(f'Failed to retrieve collection token from Secrets Manager: {str(e)}')
             return
 

--- a/modules/eks-audit/lambda/index.py
+++ b/modules/eks-audit/lambda/index.py
@@ -4,6 +4,7 @@ import json
 import boto3
 import logging
 from botocore.exceptions import ClientError
+from urllib3.exceptions import HTTPError
 
 logger = logging.getLogger("EKS-Audit-Collector")
 logger.setLevel(logging.INFO)
@@ -44,7 +45,7 @@ def handler(event, context):
             timeout=urllib3.Timeout(connect=2, read=5),
             retries=urllib3.util.Retry(total=2, status_forcelist=[500, 502, 503, 504])
         )
-    except Exception as e:
+    except HTTPError as e:
         logger.error(f'Failed to forward logs: {str(e)}')
         return
 

--- a/modules/eks-audit/main.tf
+++ b/modules/eks-audit/main.tf
@@ -1,0 +1,164 @@
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+data "streamsec_host" "this" {}
+data "streamsec_aws_account" "this" {
+  cloud_account_id = data.aws_caller_identity.current.account_id
+}
+
+data "aws_eks_clusters" "this" {}
+
+resource "random_string" "suffix" {
+  length  = 6
+  upper   = false
+  special = false
+}
+
+locals {
+  name_prefix = var.resource_prefix != "" ? "${var.resource_prefix}-StreamSecurity" : "StreamSecurity"
+
+  discovered_clusters = data.aws_eks_clusters.this.names
+
+  included_clusters = length(var.eks_include_clusters) > 0 ? (
+    [for c in local.discovered_clusters : c if contains(var.eks_include_clusters, c)]
+  ) : local.discovered_clusters
+
+  target_clusters = [for c in local.included_clusters : c if !contains(var.eks_exclude_clusters, c)]
+
+  cluster_log_groups = {
+    for c in local.target_clusters : c => "/aws/eks/${c}/cluster"
+  }
+
+  create_role = var.collector_role_arn == null
+  role_arn    = local.create_role ? aws_iam_role.collector[0].arn : var.collector_role_arn
+
+  eks_audit_filter_pattern = <<-EOT
+{(($.sourceIPs[0] != "::1" && $.sourceIPs[0] != "127.0.0.1") || ($.sourceIPs[1] != "::1" && $.sourceIPs[1] != "127.0.0.1")) && $.stage = "ResponseComplete" && $.verb != "watch" && $.user.username != "system:kube*" && $.user.username != "eks:*" && ($.objectRef.resource not exists || ($.objectRef.resource != "events" && $.objectRef.resource != "leases")) && ($.objectRef.subresource not exists || ($.objectRef.subresource != "status" && $.objectRef.subresource != "scale" && $.objectRef.subresource != "proxy" && $.objectRef.subresource != "token" && ($.objectRef.subresource != "binding" || ($.objectRef.subresource = "binding" && $.responseStatus.code != 201))))}
+EOT
+}
+
+################################################################################
+# IAM Role (conditional)
+################################################################################
+
+resource "aws_iam_role" "collector" {
+  count = local.create_role ? 1 : 0
+
+  name = "${local.name_prefix}-eks-audit-collector-role-${random_string.suffix.result}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
+  count = local.create_role ? 1 : 0
+
+  role       = aws_iam_role.collector[0].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy" "secrets_access" {
+  name = "${local.name_prefix}-eks-audit-secrets-policy-${random_string.suffix.result}"
+  role = local.create_role ? aws_iam_role.collector[0].id : regex("[^/]+$", var.collector_role_arn)
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue"
+        ]
+        Resource = aws_secretsmanager_secret.collection_token.arn
+      }
+    ]
+  })
+}
+
+################################################################################
+# Secrets Manager
+################################################################################
+
+resource "aws_secretsmanager_secret" "collection_token" {
+  name                    = "${var.collection_token_secret_name}-${random_string.suffix.result}"
+  description             = "Stream Security EKS audit collection token"
+  recovery_window_in_days = 0
+  tags                    = var.tags
+}
+
+resource "aws_secretsmanager_secret_version" "collection_token" {
+  secret_id     = aws_secretsmanager_secret.collection_token.id
+  secret_string = data.streamsec_aws_account.this.streamsec_collection_token
+}
+
+################################################################################
+# Lambda Function
+################################################################################
+
+data "archive_file" "collector" {
+  type        = "zip"
+  source_file = "${path.module}/lambda/index.py"
+  output_path = "${path.module}/lambda/index.zip"
+}
+
+resource "aws_cloudwatch_log_group" "collector" {
+  name              = "/aws/lambda/${local.name_prefix}-eks-audit-collector-${random_string.suffix.result}"
+  retention_in_days = var.lambda_log_retention_days
+  tags              = var.tags
+}
+
+resource "aws_lambda_function" "collector" {
+  function_name = "${local.name_prefix}-eks-audit-collector-${random_string.suffix.result}"
+  role          = local.role_arn
+  handler       = "index.handler"
+  runtime       = "python3.13"
+  memory_size   = var.collector_lambda_memory_size
+  timeout       = var.collector_lambda_timeout
+
+  filename         = data.archive_file.collector.output_path
+  source_code_hash = data.archive_file.collector.output_base64sha256
+
+  environment {
+    variables = {
+      FORWARD_URL = data.streamsec_host.this.url
+      SECRET_NAME = aws_secretsmanager_secret.collection_token.name
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.collector]
+
+  tags = var.tags
+}
+
+################################################################################
+# CloudWatch Log Subscription Filters
+################################################################################
+
+resource "aws_lambda_permission" "allow_cloudwatch_logs" {
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.collector.arn
+  principal     = "logs.amazonaws.com"
+  source_arn    = "arn:aws:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:log-group:/aws/eks/*"
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "eks_audit" {
+  for_each = local.cluster_log_groups
+
+  name            = "${local.name_prefix}_eks_cw_rule_${each.key}_${random_string.suffix.result}"
+  log_group_name  = each.value
+  filter_pattern  = trimspace(local.eks_audit_filter_pattern)
+  destination_arn = aws_lambda_function.collector.arn
+
+  depends_on = [aws_lambda_permission.allow_cloudwatch_logs]
+}

--- a/modules/eks-audit/main.tf
+++ b/modules/eks-audit/main.tf
@@ -93,7 +93,7 @@ resource "aws_iam_role_policy" "secrets_access" {
 resource "aws_secretsmanager_secret" "collection_token" {
   name                    = "${var.collection_token_secret_name}-${random_string.suffix.result}"
   description             = "Stream Security EKS audit collection token"
-  recovery_window_in_days = 0
+  recovery_window_in_days = var.secret_recovery_window_days
   tags                    = var.tags
 }
 
@@ -146,6 +146,7 @@ resource "aws_lambda_function" "collector" {
 ################################################################################
 
 resource "aws_lambda_permission" "allow_cloudwatch_logs" {
+  statement_id  = "AllowEKSAuditCWLogs-${random_string.suffix.result}"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.collector.arn
   principal     = "logs.amazonaws.com"

--- a/modules/eks-audit/main.tf
+++ b/modules/eks-audit/main.tf
@@ -28,8 +28,9 @@ locals {
     for c in local.target_clusters : c => "/aws/eks/${c}/cluster"
   }
 
-  create_role = var.collector_role_arn == null
-  role_arn    = local.create_role ? aws_iam_role.collector[0].arn : var.collector_role_arn
+  create_role    = var.collector_role_arn == null
+  role_arn       = local.create_role ? aws_iam_role.collector[0].arn : var.collector_role_arn
+  role_name_byob = var.collector_role_arn != null ? element(split("/", var.collector_role_arn), length(split("/", var.collector_role_arn)) - 1) : ""
 
   eks_audit_filter_pattern = <<-EOT
 {(($.sourceIPs[0] != "::1" && $.sourceIPs[0] != "127.0.0.1") || ($.sourceIPs[1] != "::1" && $.sourceIPs[1] != "127.0.0.1")) && $.stage = "ResponseComplete" && $.verb != "watch" && $.user.username != "system:kube*" && $.user.username != "eks:*" && ($.objectRef.resource not exists || ($.objectRef.resource != "events" && $.objectRef.resource != "leases")) && ($.objectRef.subresource not exists || ($.objectRef.subresource != "status" && $.objectRef.subresource != "scale" && $.objectRef.subresource != "proxy" && $.objectRef.subresource != "token" && ($.objectRef.subresource != "binding" || ($.objectRef.subresource = "binding" && $.responseStatus.code != 201))))}
@@ -70,7 +71,7 @@ resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
 
 resource "aws_iam_role_policy" "secrets_access" {
   name = "${local.name_prefix}-eks-audit-secrets-policy-${random_string.suffix.result}"
-  role = local.create_role ? aws_iam_role.collector[0].id : element(split("/", var.collector_role_arn), length(split("/", var.collector_role_arn)) - 1)
+  role = local.create_role ? aws_iam_role.collector[0].id : local.role_name_byob
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -119,12 +120,13 @@ resource "aws_cloudwatch_log_group" "collector" {
 }
 
 resource "aws_lambda_function" "collector" {
-  function_name = "${local.name_prefix}-eks-audit-collector-${random_string.suffix.result}"
-  role          = local.role_arn
-  handler       = "index.handler"
-  runtime       = "python3.13"
-  memory_size   = var.collector_lambda_memory_size
-  timeout       = var.collector_lambda_timeout
+  function_name                  = "${local.name_prefix}-eks-audit-collector-${random_string.suffix.result}"
+  role                           = local.role_arn
+  handler                        = "index.handler"
+  runtime                        = "python3.13"
+  memory_size                    = var.collector_lambda_memory_size
+  timeout                        = var.collector_lambda_timeout
+  reserved_concurrent_executions = var.lambda_reserved_concurrency
 
   filename         = data.archive_file.collector.output_path
   source_code_hash = data.archive_file.collector.output_base64sha256

--- a/modules/eks-audit/main.tf
+++ b/modules/eks-audit/main.tf
@@ -70,7 +70,7 @@ resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
 
 resource "aws_iam_role_policy" "secrets_access" {
   name = "${local.name_prefix}-eks-audit-secrets-policy-${random_string.suffix.result}"
-  role = local.create_role ? aws_iam_role.collector[0].id : regex("[^/]+$", var.collector_role_arn)
+  role = local.create_role ? aws_iam_role.collector[0].id : element(split("/", var.collector_role_arn), length(split("/", var.collector_role_arn)) - 1)
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -149,7 +149,7 @@ resource "aws_lambda_permission" "allow_cloudwatch_logs" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.collector.arn
   principal     = "logs.amazonaws.com"
-  source_arn    = "arn:aws:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:log-group:/aws/eks/*"
+  source_arn    = "arn:aws:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:log-group:/aws/eks/*/cluster"
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "eks_audit" {

--- a/modules/eks-audit/main.tf
+++ b/modules/eks-audit/main.tf
@@ -30,7 +30,7 @@ locals {
 
   create_role    = var.collector_role_arn == null
   role_arn       = local.create_role ? aws_iam_role.collector[0].arn : var.collector_role_arn
-  role_name_byob = var.collector_role_arn != null ? element(split("/", var.collector_role_arn), length(split("/", var.collector_role_arn)) - 1) : ""
+  role_name_byob = var.collector_role_arn != null ? element(split("/", var.collector_role_arn), length(split("/", var.collector_role_arn)) - 1) : null
 
   eks_audit_filter_pattern = <<-EOT
 {(($.sourceIPs[0] != "::1" && $.sourceIPs[0] != "127.0.0.1") || ($.sourceIPs[1] != "::1" && $.sourceIPs[1] != "127.0.0.1")) && $.stage = "ResponseComplete" && $.verb != "watch" && $.user.username != "system:kube*" && $.user.username != "eks:*" && ($.objectRef.resource not exists || ($.objectRef.resource != "events" && $.objectRef.resource != "leases")) && ($.objectRef.subresource not exists || ($.objectRef.subresource != "status" && $.objectRef.subresource != "scale" && $.objectRef.subresource != "proxy" && $.objectRef.subresource != "token" && ($.objectRef.subresource != "binding" || ($.objectRef.subresource = "binding" && $.responseStatus.code != 201))))}
@@ -71,7 +71,7 @@ resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
 
 resource "aws_iam_role_policy" "secrets_access" {
   name = "${local.name_prefix}-eks-audit-secrets-policy-${random_string.suffix.result}"
-  role = local.create_role ? aws_iam_role.collector[0].id : local.role_name_byob
+  role = local.create_role ? aws_iam_role.collector[0].name : local.role_name_byob
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -147,6 +147,8 @@ resource "aws_lambda_function" "collector" {
 # CloudWatch Log Subscription Filters
 ################################################################################
 
+# Wildcard covers all /aws/eks/*/cluster log groups — scoped to this account/region.
+# Actual invocation is limited to clusters with subscription filters (local.cluster_log_groups).
 resource "aws_lambda_permission" "allow_cloudwatch_logs" {
   statement_id  = "AllowEKSAuditCWLogs-${random_string.suffix.result}"
   action        = "lambda:InvokeFunction"

--- a/modules/eks-audit/outputs.tf
+++ b/modules/eks-audit/outputs.tf
@@ -1,0 +1,24 @@
+output "collector_lambda_arn" {
+  description = "ARN of the EKS audit collector Lambda function"
+  value       = aws_lambda_function.collector.arn
+}
+
+output "collector_lambda_name" {
+  description = "Name of the EKS audit collector Lambda function"
+  value       = aws_lambda_function.collector.function_name
+}
+
+output "collector_role_arn" {
+  description = "ARN of the IAM role used by the collector Lambda"
+  value       = local.role_arn
+}
+
+output "secret_arn" {
+  description = "ARN of the Secrets Manager secret storing the collection token"
+  value       = aws_secretsmanager_secret.collection_token.arn
+}
+
+output "subscribed_clusters" {
+  description = "List of EKS cluster names that have subscription filters"
+  value       = local.target_clusters
+}

--- a/modules/eks-audit/variables.tf
+++ b/modules/eks-audit/variables.tf
@@ -44,6 +44,12 @@ variable "lambda_log_retention_days" {
   default     = 7
 }
 
+variable "lambda_reserved_concurrency" {
+  description = "Reserved concurrent executions for the collector Lambda. Set to -1 for unreserved."
+  type        = number
+  default     = -1
+}
+
 variable "secret_recovery_window_days" {
   description = "Number of days Secrets Manager waits before deleting the secret. Set to 0 for immediate deletion."
   type        = number

--- a/modules/eks-audit/variables.tf
+++ b/modules/eks-audit/variables.tf
@@ -23,7 +23,7 @@ variable "eks_exclude_clusters" {
 variable "collection_token_secret_name" {
   description = "Base name for the Secrets Manager secret storing the collection token"
   type        = string
-  default     = "lightlytics-eks-collection-token"
+  default     = "streamsec-eks-collection-token"
 }
 
 variable "collector_lambda_memory_size" {
@@ -35,13 +35,19 @@ variable "collector_lambda_memory_size" {
 variable "collector_lambda_timeout" {
   description = "The amount of time in seconds the collector Lambda function is allowed to run"
   type        = number
-  default     = 10
+  default     = 30
 }
 
 variable "lambda_log_retention_days" {
   description = "The number of days to retain the collector Lambda CloudWatch logs"
   type        = number
-  default     = 1
+  default     = 7
+}
+
+variable "secret_recovery_window_days" {
+  description = "Number of days Secrets Manager waits before deleting the secret. Set to 0 for immediate deletion."
+  type        = number
+  default     = 0
 }
 
 variable "collector_role_arn" {

--- a/modules/eks-audit/variables.tf
+++ b/modules/eks-audit/variables.tf
@@ -1,0 +1,61 @@
+################################################################################
+# EKS Audit Collector
+################################################################################
+
+variable "resource_prefix" {
+  description = "Optional prefix prepended before StreamSecurity in all resource names"
+  type        = string
+  default     = ""
+}
+
+variable "eks_include_clusters" {
+  description = "Only subscribe these EKS clusters. If empty, all clusters in the region are included."
+  type        = list(string)
+  default     = []
+}
+
+variable "eks_exclude_clusters" {
+  description = "Skip these EKS clusters from subscription"
+  type        = list(string)
+  default     = []
+}
+
+variable "collection_token_secret_name" {
+  description = "Base name for the Secrets Manager secret storing the collection token"
+  type        = string
+  default     = "lightlytics-eks-collection-token"
+}
+
+variable "collector_lambda_memory_size" {
+  description = "The amount of memory in MB to allocate to the collector Lambda function"
+  type        = number
+  default     = 128
+}
+
+variable "collector_lambda_timeout" {
+  description = "The amount of time in seconds the collector Lambda function is allowed to run"
+  type        = number
+  default     = 10
+}
+
+variable "lambda_log_retention_days" {
+  description = "The number of days to retain the collector Lambda CloudWatch logs"
+  type        = number
+  default     = 1
+}
+
+variable "collector_role_arn" {
+  description = "If set, skip IAM role creation and use this existing role ARN for the collector Lambda"
+  type        = string
+  default     = null
+}
+
+################################################################################
+# General
+################################################################################
+
+variable "tags" {
+  description = "A map of global tags to add to all created resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/eks-audit/variables.tf
+++ b/modules/eks-audit/variables.tf
@@ -48,6 +48,10 @@ variable "collector_role_arn" {
   description = "If set, skip IAM role creation and use this existing role ARN for the collector Lambda"
   type        = string
   default     = null
+  validation {
+    condition     = var.collector_role_arn == null || can(regex("^arn:aws:iam::", var.collector_role_arn))
+    error_message = "collector_role_arn must be a valid IAM role ARN starting with arn:aws:iam::."
+  }
 }
 
 ################################################################################

--- a/modules/eks-audit/variables.tf
+++ b/modules/eks-audit/variables.tf
@@ -48,6 +48,10 @@ variable "lambda_reserved_concurrency" {
   description = "Reserved concurrent executions for the collector Lambda. Set to -1 for unreserved."
   type        = number
   default     = -1
+  validation {
+    condition     = var.lambda_reserved_concurrency >= -1
+    error_message = "lambda_reserved_concurrency must be -1 (unreserved) or a non-negative integer."
+  }
 }
 
 variable "secret_recovery_window_days" {

--- a/modules/eks-audit/versions.tf
+++ b/modules/eks-audit/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    streamsec = {
+      source  = "streamsec-terraform/streamsec"
+      version = ">= 1.7"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = ">= 2.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `modules/eks-audit` — a native Terraform replacement for the CloudFormation-based `StreamSecurity-eks-audit-logs-collector` stack
- Auto-discovers EKS clusters in the region via `aws_eks_clusters` data source
- Deploys a Python 3.13 Lambda that forwards EKS audit logs to the Stream Security API
- Creates CloudWatch Log subscription filters with the same filter pattern as the original CFT

## Features

- **Auto-discovery**: finds all EKS clusters in the region automatically
- **Include/exclude filtering**: `eks_include_clusters` and `eks_exclude_clusters` variables to control which clusters are subscribed
- **Resource prefix**: optional `resource_prefix` prepended before "StreamSecurity" in all resource names
- **Bring your own role**: pass `collector_role_arn` to skip IAM role creation and use an existing role (secrets policy is always attached)
- **Unique naming**: random suffix on all resource names prevents collisions across multi-region deployments

## Resources created

- Secrets Manager secret + version (collection token)
- IAM role + policies (conditional — skipped when `collector_role_arn` is provided)
- Lambda function (Python 3.13, inline code via `archive_file`)
- CloudWatch Log Group for Lambda
- CloudWatch Log subscription filters (one per cluster)
- Lambda permission for CloudWatch Logs

## Test plan

Tested against AWS account `014466394144` in `us-west-2` with two EKS clusters (`test-cluster-alpha`, `test-cluster-beta`):

- [x] Auto-discovery: both clusters subscribed, logs visible in Stream Security
- [x] Include filter: only included cluster logs forwarded
- [x] Exclude filter: excluded cluster logs not forwarded
- [x] Resource prefix: Lambda named `acme-StreamSecurity-eks-audit-collector-{suffix}`
- [x] BYOB role: external role used, secrets policy auto-attached, logs flowing
- [x] `terraform fmt` and `terraform validate` pass clean
- [x] All test infrastructure destroyed after testing

## Post-merge steps

- [ ] Create git tag (e.g. `v1.13.0`)
- [ ] Create GitHub release with release notes
- [ ] Update Terraform Registry (auto-syncs from tag)
- [ ] Update customer-facing docs / deployment guide with eks-audit usage