### PR TITLE
fix(eks-audit): correct CloudWatch Logs invoke permission + skip clusters without audit log groups

### DIFF
--- a/modules/eks-audit/README.md
+++ b/modules/eks-audit/README.md
@@ -4,6 +4,17 @@ Terraform module for collecting EKS audit logs and forwarding them to Stream Sec
 
 This module auto-discovers EKS clusters in the region, creates CloudWatch Log subscription filters on their audit log groups, and deploys a collector Lambda that forwards the logs to the Stream Security API.
 
+Only clusters that have audit logging enabled are connected. Clusters without audit logging are skipped (and listed in the `skipped_clusters` output) — they won't cause errors.
+
+> **First-time setup: run `terraform apply` twice.**
+> This module needs your Stream Security account to be set up before it can run. If you're deploying both for the first time in the same configuration, apply the account module first, then apply everything:
+> ```bash
+> # Replace "account" with the name you gave the Stream Security account module
+> terraform apply -target=module.account
+> terraform apply
+> ```
+> After that, normal `terraform apply` works as usual.
+
 ## Usage
 
 ```hcl
@@ -60,6 +71,10 @@ module "eks_audit_us_west_2" {
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 | <a name="provider_streamsec"></a> [streamsec](#provider\_streamsec) | >= 1.7 |
 
+## Modules
+
+No modules.
+
 ## Resources
 
 | Name | Type |
@@ -74,7 +89,9 @@ module "eks_audit_us_west_2" {
 | [aws_secretsmanager_secret.collection_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret_version.collection_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [random_string.suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
+| [archive_file.collector](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_cloudwatch_log_groups.eks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudwatch_log_groups) | data source |
 | [aws_eks_clusters.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_clusters) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [streamsec_aws_account.this](https://registry.terraform.io/providers/streamsec-terraform/streamsec/latest/docs/data-sources/aws_account) | data source |
@@ -91,6 +108,7 @@ module "eks_audit_us_west_2" {
 | <a name="input_eks_exclude_clusters"></a> [eks\_exclude\_clusters](#input\_eks\_exclude\_clusters) | Skip these EKS clusters from subscription | `list(string)` | `[]` | no |
 | <a name="input_eks_include_clusters"></a> [eks\_include\_clusters](#input\_eks\_include\_clusters) | Only subscribe these EKS clusters. If empty, all clusters in the region are included. | `list(string)` | `[]` | no |
 | <a name="input_lambda_log_retention_days"></a> [lambda\_log\_retention\_days](#input\_lambda\_log\_retention\_days) | The number of days to retain the collector Lambda CloudWatch logs | `number` | `7` | no |
+| <a name="input_lambda_reserved_concurrency"></a> [lambda\_reserved\_concurrency](#input\_lambda\_reserved\_concurrency) | Reserved concurrent executions for the collector Lambda. Set to -1 for unreserved. | `number` | `-1` | no |
 | <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | Optional prefix prepended before StreamSecurity in all resource names | `string` | `""` | no |
 | <a name="input_secret_recovery_window_days"></a> [secret\_recovery\_window\_days](#input\_secret\_recovery\_window\_days) | Number of days Secrets Manager waits before deleting the secret. Set to 0 for immediate deletion. | `number` | `0` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of global tags to add to all created resources | `map(string)` | `{}` | no |
@@ -103,5 +121,6 @@ module "eks_audit_us_west_2" {
 | <a name="output_collector_lambda_name"></a> [collector\_lambda\_name](#output\_collector\_lambda\_name) | Name of the EKS audit collector Lambda function |
 | <a name="output_collector_role_arn"></a> [collector\_role\_arn](#output\_collector\_role\_arn) | ARN of the IAM role used by the collector Lambda |
 | <a name="output_secret_arn"></a> [secret\_arn](#output\_secret\_arn) | ARN of the Secrets Manager secret storing the collection token |
+| <a name="output_skipped_clusters"></a> [skipped\_clusters](#output\_skipped\_clusters) | Map of EKS cluster name => reason for clusters that were skipped (no control-plane log group / audit logging disabled) |
 | <a name="output_subscribed_clusters"></a> [subscribed\_clusters](#output\_subscribed\_clusters) | List of EKS cluster names that have subscription filters |
 <!-- END_TF_DOCS -->

--- a/modules/eks-audit/main.tf
+++ b/modules/eks-audit/main.tf
@@ -7,6 +7,13 @@ data "streamsec_aws_account" "this" {
 
 data "aws_eks_clusters" "this" {}
 
+# Used to skip clusters whose control-plane log group doesn't exist yet (audit/
+# control-plane logging disabled). Subscribing to a missing log group fails the
+# whole apply with ResourceNotFoundException.
+data "aws_cloudwatch_log_groups" "eks" {
+  log_group_name_prefix = "/aws/eks/"
+}
+
 resource "random_string" "suffix" {
   length  = 6
   upper   = false
@@ -24,8 +31,26 @@ locals {
 
   target_clusters = [for c in local.included_clusters : c if !contains(var.eks_exclude_clusters, c)]
 
+  # Single source of truth: does each targeted cluster have a control-plane log
+  # group? Note this is read at plan time, so a cluster whose audit logging was
+  # just enabled may not be discovered until a later apply.
+  cluster_has_log_group = {
+    for c in local.target_clusters : c => contains(data.aws_cloudwatch_log_groups.eks.log_group_names, "/aws/eks/${c}/cluster")
+  }
+
+  # Only subscribe clusters whose log group actually exists; skipping the rest
+  # avoids a ResourceNotFoundException that would fail the entire apply.
   cluster_log_groups = {
     for c in local.target_clusters : c => "/aws/eks/${c}/cluster"
+    if local.cluster_has_log_group[c]
+  }
+
+  # Targeted clusters dropped because their control-plane log group is absent
+  # (control-plane/audit logging disabled). Surfaced via output as a map of
+  # cluster name => reason, so the skip is both visible and self-explanatory.
+  skipped_clusters = {
+    for c in local.target_clusters : c => "no audit log group (/aws/eks/${c}/cluster) — enable control-plane audit logging on this cluster"
+    if !local.cluster_has_log_group[c]
   }
 
   create_role    = var.collector_role_arn == null
@@ -154,7 +179,7 @@ resource "aws_lambda_permission" "allow_cloudwatch_logs" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.collector.arn
   principal     = "logs.amazonaws.com"
-  source_arn    = "arn:aws:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:log-group:/aws/eks/*/cluster"
+  source_arn    = "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/eks/*/cluster:*"
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "eks_audit" {

--- a/modules/eks-audit/outputs.tf
+++ b/modules/eks-audit/outputs.tf
@@ -20,5 +20,10 @@ output "secret_arn" {
 
 output "subscribed_clusters" {
   description = "List of EKS cluster names that have subscription filters"
-  value       = local.target_clusters
+  value       = [for c in local.target_clusters : c if local.cluster_has_log_group[c]]
+}
+
+output "skipped_clusters" {
+  description = "Map of EKS cluster name => reason for clusters that were skipped (no control-plane log group / audit logging disabled)"
+  value       = local.skipped_clusters
 }

--- a/modules/eks-audit/variables.tf
+++ b/modules/eks-audit/variables.tf
@@ -65,8 +65,8 @@ variable "collector_role_arn" {
   type        = string
   default     = null
   validation {
-    condition     = var.collector_role_arn == null || can(regex("^arn:aws:iam::", var.collector_role_arn))
-    error_message = "collector_role_arn must be a valid IAM role ARN starting with arn:aws:iam::."
+    condition     = var.collector_role_arn == null || can(regex("^arn:aws:iam::[0-9]{12}:role/", var.collector_role_arn))
+    error_message = "collector_role_arn must be a valid IAM role ARN of the form arn:aws:iam::<account-id>:role/<name>."
   }
 }
 

--- a/modules/real-time-events/main.tf
+++ b/modules/real-time-events/main.tf
@@ -225,7 +225,7 @@ resource "aws_lambda_permission" "streamsec_allow_cwlogs_invocation" {
   count         = length(local.central_log_subscriptions) > 0 ? 1 : 0
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.streamsec_real_time_events_lambda.function_name
-  principal     = "logs.${data.aws_region.current.name}.amazonaws.com"
+  principal     = "logs.${data.aws_region.current.region}.amazonaws.com"
   source_account = data.aws_caller_identity.current.account_id
 }
 


### PR DESCRIPTION
## What

Fixes the EKS audit module failing with
`InvalidParameterException: Could not execute the lambda function. Make sure you
have given CloudWatch Logs permission to execute your function` when creating the
CloudWatch Logs subscription filter.

## Changes

- **Permission fix** — the collector Lambda's `aws_lambda_permission.source_arn`
  was missing the trailing `:*` that CloudWatch Logs presents (and used the
  deprecated `.id`). It's now `.../aws/eks/*/cluster:*` using `.region`, so
  `PutSubscriptionFilter` succeeds.
- **Graceful skip** — clusters whose control-plane/audit log group does not exist
  are now skipped (and reported in a new `skipped_clusters` output) instead of
  failing the entire apply with `ResourceNotFoundException`.
- **Validation** — `collector_role_arn` must now be a real role ARN
  (`arn:aws:iam::<account-id>:role/<name>`), failing at plan rather than apply.
- **real-time-events** — replaced the deprecated `aws_region.current.name` with
  `.region`.
- **Docs** — documented the first-time two-pass apply (account module first).

## Testing

- `terraform validate` / `terraform fmt`.
- Verified end-to-end against a live AWS account: the subscription filter is
  created successfully and audit logs are forwarded to the collector (HTTP 200).
- Skip path: a cluster with audit logging disabled is reported in
  `skipped_clusters` and the apply succeeds (previously this failed the whole
  apply with `ResourceNotFoundException`).
