### PR TITLE
feat: collect API Gateway, ALB, and S3 access logs

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -36,7 +36,14 @@ module "real_time_us_east_1" {
   # central_eks_audit_log_groups     = ["/aws/eks/my-cluster/cluster"]
   # central_route53_log_groups       = ["/staging/route53dnslogs/cw-test"]
   # central_bedrock_log_groups       = ["/staging/awsbedrocklogs/cw-test"]
-  # central_kinesis_stream_arns     = ["arn:aws:kinesis:us-east-1:123456789012:stream/my-stream"]
+  # central_kinesis_stream_arns      = ["arn:aws:kinesis:us-east-1:123456789012:stream/my-stream"]
+
+  # API Gateway access logs via CloudWatch Logs (or via the Kinesis stream above).
+  # central_apigateway_log_format is REQUIRED whenever central_apigateway_log_groups is set —
+  # it must match the access-log format configured on the API stage, or the logs are skipped.
+  # central_apigateway_log_groups    = ["/aws/apigateway/my-api/access-logs"]
+  # Include $context.apiId so the platform can attribute logs to the API resource (without it they show as "unknown"). domainName/stage recommended too.
+  # central_apigateway_log_format    = "{\"apiId\":\"$context.apiId\",\"domainName\":\"$context.domainName\",\"stage\":\"$context.stage\",\"requestId\":\"$context.requestId\",\"ip\":\"$context.identity.sourceIp\",\"httpMethod\":\"$context.httpMethod\",\"path\":\"$context.path\",\"status\":\"$context.status\"}"
 }
 
 module "real_time_us_east_2" {
@@ -57,7 +64,23 @@ module "flow_logs" {
 module "iam_activity" {
   source                   = "../../modules/iam-activity"
   iam_activity_bucket_name = "xxxxxxxxxxxxx"
-  depends_on               = [module.account]
+
+  # Optional: collect API Gateway access logs from an existing bucket (must be in the same region; e.g. fed via Firehose).
+  # PREREQUISITE: EventBridge notifications must be enabled on the bucket (Properties -> Amazon EventBridge).
+  # apigateway_bucket_name   = "my-apigateway-access-logs"
+  # apigateway_log_format    = "{\"apiId\":\"$context.apiId\",\"domainName\":\"$context.domainName\",\"stage\":\"$context.stage\",\"requestId\":\"$context.requestId\",\"ip\":\"$context.identity.sourceIp\",\"httpMethod\":\"$context.httpMethod\",\"path\":\"$context.path\",\"status\":\"$context.status\"}" # must match the format set on the API stage (required); include $context.apiId for resource attribution
+  # apigateway_s3_key_prefix = "apigw/"   # only match/read objects under this prefix
+  # apigateway_kms_key_arn   = "arn:aws:kms:us-east-1:123456789012:key/xxxx" # if the bucket uses SSE-KMS
+
+  # Optional: collect S3 server access logs from an existing target bucket (same prerequisites as above)
+  # s3_access_logs_bucket_name = "my-s3-access-logs"
+  # s3_access_logs_key_prefix  = "access-logs/"
+
+  # Optional: collect ALB access logs from an existing target bucket (same prerequisites as above)
+  # alb_access_logs_bucket_name = "my-alb-access-logs"
+  # alb_access_logs_key_prefix  = "AWSLogs/"
+
+  depends_on = [module.account]
 }
 
 module "cost" {

--- a/modules/iam-activity/README.md
+++ b/modules/iam-activity/README.md
@@ -3,16 +3,16 @@
 ## Requirements
 
 | Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 | <a name="requirement_streamsec"></a> [streamsec](#requirement\_streamsec) | >= 1.7 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 | <a name="provider_streamsec"></a> [streamsec](#provider\_streamsec) | >= 1.7 |
 
 ## Modules
@@ -22,8 +22,10 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
+| [aws_cloudwatch_event_rule.collection_bucket_trigger](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_rule.iam_activity_s3_eventbridge_trigger](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_target.collection_bucket_target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_cloudwatch_event_target.iam_activity_s3_eventbridge_target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_iam_policy.lambda_exec_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.lambda_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -32,6 +34,7 @@ No modules.
 | [aws_lambda_function.streamsec_iam_activity_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_function_event_invoke_config.streamsec_options_cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function_event_invoke_config) | resource |
 | [aws_lambda_layer_version.streamsec_lambda_layer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_layer_version) | resource |
+| [aws_lambda_permission.collection_bucket_allow_invoke](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_lambda_permission.iam_activity_s3_allow_invoke](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_lambda_permission.streamsec_iam_activity_allow_s3_invoke](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_s3_bucket_notification.bucket_notification](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
@@ -40,6 +43,7 @@ No modules.
 | [aws_secretsmanager_secret_version.streamsec_collection_secret_version](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [aws_s3_bucket.collection_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
 | [aws_s3_bucket.iam_activity_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
 | [streamsec_aws_account.this](https://registry.terraform.io/providers/streamsec-terraform/streamsec/latest/docs/data-sources/aws_account) | data source |
 | [streamsec_host.this](https://registry.terraform.io/providers/streamsec-terraform/streamsec/latest/docs/data-sources/host) | data source |
@@ -47,7 +51,16 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_alb_access_logs_bucket_name"></a> [alb\_access\_logs\_bucket\_name](#input\_alb\_access\_logs\_bucket\_name) | (Optional) Name of an EXISTING S3 bucket (in the same region as this module's provider) that is the target of ALB/ELB access logging. PREREQUISITE: EventBridge notifications must be enabled on the bucket, see: https://docs.streamsec.io/docs/configure-s3-event-notifications-with-amazon-eventbridge. When set, the module creates an EventBridge rule that forwards new objects to the collector Lambda. The bucket is NOT created or modified by this module. Must be a static string known at plan time, and must differ from iam\_activity\_bucket\_name. | `string` | `null` | no |
+| <a name="input_alb_access_logs_key_prefix"></a> [alb\_access\_logs\_key\_prefix](#input\_alb\_access\_logs\_key\_prefix) | (Optional) S3 key prefix of the ALB access log objects (the prefix configured on the load balancer's access\_logs attribute). When set, the EventBridge rule only matches objects under this prefix and the Lambda's s3:GetObject permission is scoped to it. | `string` | `null` | no |
+| <a name="input_alb_access_logs_kms_key_arn"></a> [alb\_access\_logs\_kms\_key\_arn](#input\_alb\_access\_logs\_kms\_key\_arn) | (Optional) ARN of the KMS key used to encrypt objects in the ALB access logs bucket (SSE-KMS). When set, the Lambda execution role is granted kms:Decrypt on this key. | `string` | `null` | no |
+| <a name="input_apigateway_bucket_name"></a> [apigateway\_bucket\_name](#input\_apigateway\_bucket\_name) | (Optional) Name of an EXISTING S3 bucket (in the same region as this module's provider) that already receives API Gateway access logs (e.g. delivered via Kinesis Data Firehose). PREREQUISITE: EventBridge notifications must be enabled on the bucket, see: https://docs.streamsec.io/docs/configure-s3-event-notifications-with-amazon-eventbridge. When set, the module creates an EventBridge rule that forwards new objects to the collector Lambda. The bucket is NOT created or modified by this module. Must be a static string known at plan time, and must differ from iam\_activity\_bucket\_name. | `string` | `null` | no |
+| <a name="input_apigateway_kms_key_arn"></a> [apigateway\_kms\_key\_arn](#input\_apigateway\_kms\_key\_arn) | (Optional) ARN of the KMS key used to encrypt objects in the API Gateway bucket (SSE-KMS). When set, the Lambda execution role is granted kms:Decrypt on this key. | `string` | `null` | no |
+| <a name="input_apigateway_log_format"></a> [apigateway\_log\_format](#input\_apigateway\_log\_format) | The API Gateway access log format string configured on the API stage (JSON or delimited $context.* format). REQUIRED when apigateway\_bucket\_name is set — the collector uses it to parse the log lines and ignores API Gateway objects without it. | `string` | `null` | no |
+| <a name="input_apigateway_s3_eventbridge_rule_description"></a> [apigateway\_s3\_eventbridge\_rule\_description](#input\_apigateway\_s3\_eventbridge\_rule\_description) | The description of the EventBridge rule to create for the API Gateway access logs S3 bucket | `string` | `"Stream Security API Gateway Access Logs S3 EventBridge Rule"` | no |
+| <a name="input_apigateway_s3_eventbridge_rule_name"></a> [apigateway\_s3\_eventbridge\_rule\_name](#input\_apigateway\_s3\_eventbridge\_rule\_name) | The name of the EventBridge rule to create for the API Gateway access logs S3 bucket. Defaults to a unique name derived from the bucket name. | `string` | `null` | no |
+| <a name="input_apigateway_s3_key_prefix"></a> [apigateway\_s3\_key\_prefix](#input\_apigateway\_s3\_key\_prefix) | (Optional) S3 key prefix of the API Gateway access log objects (e.g. the Firehose delivery prefix). When set, the EventBridge rule only matches objects under this prefix, the Lambda's s3:GetObject permission is scoped to it, and the collector filters object keys by it. | `string` | `null` | no |
 | <a name="input_collection_iam_activity_token_secret_name"></a> [collection\_iam\_activity\_token\_secret\_name](#input\_collection\_iam\_activity\_token\_secret\_name) | The name of the secret to use for the lambda function | `string` | `"streamsec-collection-token-iam-activity"` | no |
 | <a name="input_iam_activity_bucket_name"></a> [iam\_activity\_bucket\_name](#input\_iam\_activity\_bucket\_name) | The name of the S3 bucket to store the iam activity logs | `string` | n/a | yes |
 | <a name="input_iam_activity_s3_eventbridge_rule_description"></a> [iam\_activity\_s3\_eventbridge\_rule\_description](#input\_iam\_activity\_s3\_eventbridge\_rule\_description) | The description of the eventbridge rule to create for the S3 bucket | `string` | `"Stream Security IAM Activity S3 EventBridge Rule"` | no |
@@ -58,7 +71,7 @@ No modules.
 | <a name="input_lambda_cloudwatch_max_event_age"></a> [lambda\_cloudwatch\_max\_event\_age](#input\_lambda\_cloudwatch\_max\_event\_age) | The maximum age of a request that Lambda sends to a function for processing, in seconds | `number` | `21600` | no |
 | <a name="input_lambda_cloudwatch_max_retry"></a> [lambda\_cloudwatch\_max\_retry](#input\_lambda\_cloudwatch\_max\_retry) | The maximum number of times to retry when the function returns an error | `number` | `2` | no |
 | <a name="input_lambda_cloudwatch_memory_size"></a> [lambda\_cloudwatch\_memory\_size](#input\_lambda\_cloudwatch\_memory\_size) | The amount of memory in MB to allocate to the lambda function | `number` | `256` | no |
-| <a name="input_lambda_cloudwatch_s3_source_code_key"></a> [lambda\_cloudwatch\_s3\_source\_code\_key](#input\_lambda\_cloudwatch\_s3\_source\_code\_key) | The S3 key for the lambda source code | `string` | `"4f9189e262201912b0b9b86fdf6ffebb"` | no |
+| <a name="input_lambda_cloudwatch_s3_source_code_key"></a> [lambda\_cloudwatch\_s3\_source\_code\_key](#input\_lambda\_cloudwatch\_s3\_source\_code\_key) | The S3 key for the lambda source code | `string` | `"4a752d836232381fc3c72ac51458c1bc"` | no |
 | <a name="input_lambda_cloudwatch_timeout"></a> [lambda\_cloudwatch\_timeout](#input\_lambda\_cloudwatch\_timeout) | The amount of time in seconds the lambda function is allowed to run | `number` | `60` | no |
 | <a name="input_lambda_iam_role_description"></a> [lambda\_iam\_role\_description](#input\_lambda\_iam\_role\_description) | Description to use on IAM role created | `string` | `"Stream Security IAM Role"` | no |
 | <a name="input_lambda_iam_role_name"></a> [lambda\_iam\_role\_name](#input\_lambda\_iam\_role\_name) | Name to use on IAM role created | `string` | `"streamsec-iam-activity-execution-role"` | no |
@@ -66,7 +79,7 @@ No modules.
 | <a name="input_lambda_iam_role_tags"></a> [lambda\_iam\_role\_tags](#input\_lambda\_iam\_role\_tags) | A map of additional tags to add to the IAM role created | `map(string)` | `{}` | no |
 | <a name="input_lambda_iam_role_use_name_prefix"></a> [lambda\_iam\_role\_use\_name\_prefix](#input\_lambda\_iam\_role\_use\_name\_prefix) | Determines whether the IAM role name (`iam_role_name`) is used as a prefix | `bool` | `true` | no |
 | <a name="input_lambda_layer_name"></a> [lambda\_layer\_name](#input\_lambda\_layer\_name) | The name of the lambda layer | `string` | `"streamsec-iam-activity-layer"` | no |
-| <a name="input_lambda_layer_s3_source_code_key"></a> [lambda\_layer\_s3\_source\_code\_key](#input\_lambda\_layer\_s3\_source\_code\_key) | The S3 key for the lambda source code | `string` | `"98919b98292d9b3ec577cb43bd280a2a"` | no |
+| <a name="input_lambda_layer_s3_source_code_key"></a> [lambda\_layer\_s3\_source\_code\_key](#input\_lambda\_layer\_s3\_source\_code\_key) | The S3 key for the lambda source code | `string` | `"1e8d00c5c5513f60c336658713ee2cd5"` | no |
 | <a name="input_lambda_name"></a> [lambda\_name](#input\_lambda\_name) | Name of the lambda function | `string` | `"streamsec-iam-activity-lambda"` | no |
 | <a name="input_lambda_policy_description"></a> [lambda\_policy\_description](#input\_lambda\_policy\_description) | Description to use on IAM policy created | `string` | `"Stream Security IAM Policy for iam_activity lambda"` | no |
 | <a name="input_lambda_policy_name"></a> [lambda\_policy\_name](#input\_lambda\_policy\_name) | Name to use on IAM policy created | `string` | `"streamsec-iam-activity-policy"` | no |
@@ -77,6 +90,9 @@ No modules.
 | <a name="input_lambda_source_code_bucket_prefix"></a> [lambda\_source\_code\_bucket\_prefix](#input\_lambda\_source\_code\_bucket\_prefix) | The prefix to use for the lambda source code bucket | `string` | `"prod-lightlytics-artifacts"` | no |
 | <a name="input_lambda_subnet_ids"></a> [lambda\_subnet\_ids](#input\_lambda\_subnet\_ids) | The subnet IDs to use for the lambda function | `list(string)` | `[]` | no |
 | <a name="input_lambda_tags"></a> [lambda\_tags](#input\_lambda\_tags) | A map of tags to add to the lambda created | `map(string)` | `{}` | no |
+| <a name="input_s3_access_logs_bucket_name"></a> [s3\_access\_logs\_bucket\_name](#input\_s3\_access\_logs\_bucket\_name) | (Optional) Name of an EXISTING S3 bucket (in the same region as this module's provider) that is the target of S3 server access logging. PREREQUISITE: EventBridge notifications must be enabled on the bucket, see: https://docs.streamsec.io/docs/configure-s3-event-notifications-with-amazon-eventbridge. When set, the module creates an EventBridge rule that forwards new objects to the collector Lambda. The bucket is NOT created or modified by this module. Must be a static string known at plan time, and must differ from iam\_activity\_bucket\_name. | `string` | `null` | no |
+| <a name="input_s3_access_logs_key_prefix"></a> [s3\_access\_logs\_key\_prefix](#input\_s3\_access\_logs\_key\_prefix) | (Optional) S3 key prefix of the S3 access log objects (the target prefix configured on server access logging). When set, the EventBridge rule only matches objects under this prefix and the Lambda's s3:GetObject permission is scoped to it. | `string` | `null` | no |
+| <a name="input_s3_access_logs_kms_key_arn"></a> [s3\_access\_logs\_kms\_key\_arn](#input\_s3\_access\_logs\_kms\_key\_arn) | (Optional) ARN of the KMS key used to encrypt objects in the S3 access logs bucket (SSE-KMS). When set, the Lambda execution role is granted kms:Decrypt on this key. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of global tags to add to all created resources | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/modules/iam-activity/main.tf
+++ b/modules/iam-activity/main.tf
@@ -9,6 +9,54 @@ locals {
   lambda_source_code_bucket = "${var.lambda_source_code_bucket_prefix}-${data.aws_region.current.region}"
 
   compatible_runtimes = formatlist(var.lambda_runtime)
+
+  apigateway_enabled = var.apigateway_bucket_name != null
+
+  # Additional EXISTING buckets whose new objects are forwarded to the collector
+  # Lambda via EventBridge. Each entry becomes a rule/target/permission set and
+  # an s3:GetObject grant (scoped to key_prefix when provided).
+  collection_bucket_sources = {
+    apigateway = {
+      bucket_name      = var.apigateway_bucket_name
+      key_prefix       = var.apigateway_s3_key_prefix
+      kms_key_arn      = var.apigateway_kms_key_arn
+      rule_name        = var.apigateway_s3_eventbridge_rule_name
+      rule_description = var.apigateway_s3_eventbridge_rule_description
+    }
+    s3-access-logs = {
+      bucket_name      = var.s3_access_logs_bucket_name
+      key_prefix       = var.s3_access_logs_key_prefix
+      kms_key_arn      = var.s3_access_logs_kms_key_arn
+      rule_name        = null
+      rule_description = "Stream Security S3 Access Logs S3 EventBridge Rule"
+    }
+    alb-access-logs = {
+      bucket_name      = var.alb_access_logs_bucket_name
+      key_prefix       = var.alb_access_logs_key_prefix
+      kms_key_arn      = var.alb_access_logs_kms_key_arn
+      rule_name        = null
+      rule_description = "Stream Security ALB Access Logs S3 EventBridge Rule"
+    }
+  }
+
+  collection_buckets = { for k, v in local.collection_bucket_sources : k => v if v.bucket_name != null }
+
+  collection_kms_key_arns = distinct([for v in values(local.collection_buckets) : v.kms_key_arn if v.kms_key_arn != null])
+
+  # Buckets the collector Lambda is allowed to read from: always the IAM activity
+  # bucket, plus every connected collection bucket.
+  s3_read_resources = concat(
+    [
+      data.aws_s3_bucket.iam_activity_bucket.arn,
+      "${data.aws_s3_bucket.iam_activity_bucket.arn}/*",
+    ],
+    flatten([
+      for k, v in local.collection_buckets : [
+        data.aws_s3_bucket.collection_bucket[k].arn,
+        "${data.aws_s3_bucket.collection_bucket[k].arn}/${v.key_prefix != null ? v.key_prefix : ""}*",
+      ]
+    ])
+  )
 }
 
 ################################################################################
@@ -44,27 +92,35 @@ resource "aws_iam_policy" "lambda_exec_policy" {
 
   policy = jsonencode({
     "Version" : "2012-10-17"
-    "Statement" : [
-      {
-        Action = [
-          "secretsmanager:GetSecretValue"
-        ],
-        Effect   = "Allow",
-        Resource = "arn:aws:secretsmanager:*:${data.aws_caller_identity.current.account_id}:secret:${var.collection_iam_activity_token_secret_name}*"
-      },
-      # s3 permissions
-      {
-        Action = [
-          "s3:GetObject",
-        ],
-        Effect = "Allow",
-        Resource = [
-          data.aws_s3_bucket.iam_activity_bucket.arn,
-          "${data.aws_s3_bucket.iam_activity_bucket.arn}/*"
-        ]
-      },
-    ]
-
+    "Statement" : concat(
+      [
+        {
+          Action = [
+            "secretsmanager:GetSecretValue"
+          ],
+          Effect   = "Allow",
+          Resource = "arn:aws:secretsmanager:*:${data.aws_caller_identity.current.account_id}:secret:${var.collection_iam_activity_token_secret_name}*"
+        },
+        # s3 permissions
+        {
+          Action = [
+            "s3:GetObject",
+          ],
+          Effect   = "Allow",
+          Resource = local.s3_read_resources
+        },
+      ],
+      # decrypt SSE-KMS objects in the connected collection buckets
+      length(local.collection_kms_key_arns) > 0 ? [
+        {
+          Action = [
+            "kms:Decrypt",
+          ],
+          Effect   = "Allow",
+          Resource = local.collection_kms_key_arns
+        },
+      ] : []
+    )
   })
 
   tags = merge(var.tags, var.iam_policy_tags)
@@ -117,13 +173,26 @@ resource "aws_lambda_function" "streamsec_iam_activity_lambda" {
   }
 
   environment {
-    variables = {
-      API_TOKEN   = var.collection_iam_activity_token_secret_name
-      SECRET_NAME = var.collection_iam_activity_token_secret_name
-      API_URL     = data.streamsec_host.this.url
-      BATCH_SIZE  = var.lambda_batch_size
-      ENV         = "production"
-      NODE_ENV    = "production"
+    variables = merge(
+      {
+        API_TOKEN   = var.collection_iam_activity_token_secret_name
+        SECRET_NAME = var.collection_iam_activity_token_secret_name
+        API_URL     = data.streamsec_host.this.url
+        BATCH_SIZE  = var.lambda_batch_size
+        ENV         = "production"
+        NODE_ENV    = "production"
+      },
+      # enables API Gateway access-log collection in the collector and tells it
+      # how to parse the customer-defined log format
+      local.apigateway_enabled ? { API_GATEWAY_LOG_FORMAT = var.apigateway_log_format } : {},
+      local.apigateway_enabled && var.apigateway_s3_key_prefix != null ? { API_GATEWAY_S3_KEY_PATTERN = var.apigateway_s3_key_prefix } : {}
+    )
+  }
+
+  lifecycle {
+    precondition {
+      condition     = !local.apigateway_enabled || var.apigateway_log_format != null
+      error_message = "apigateway_log_format is required when apigateway_bucket_name is set: the collector cannot parse API Gateway access logs without the stage's log format string."
     }
   }
 
@@ -203,4 +272,80 @@ resource "aws_lambda_permission" "iam_activity_s3_allow_invoke" {
   function_name = aws_lambda_function.streamsec_iam_activity_lambda.arn
   principal     = "events.amazonaws.com"
   source_arn    = aws_cloudwatch_event_rule.iam_activity_s3_eventbridge_trigger[0].arn
+}
+
+
+################################################################################
+# Additional Collection Buckets (existing buckets, EventBridge only)
+# API Gateway access logs / S3 access logs / ALB access logs
+################################################################################
+
+data "aws_s3_bucket" "collection_bucket" {
+  for_each = local.collection_buckets
+  bucket   = each.value.bucket_name
+
+  lifecycle {
+    precondition {
+      condition     = each.value.bucket_name != var.iam_activity_bucket_name
+      error_message = "Collection bucket names must differ from iam_activity_bucket_name: two notification/trigger configurations on the same bucket overwrite each other and cause duplicate Lambda invocations."
+    }
+    precondition {
+      condition     = length([for v in values(local.collection_buckets) : v.bucket_name if v.bucket_name == each.value.bucket_name]) == 1
+      error_message = "Each collection bucket name must be used by only one source (apigateway / s3_access_logs / alb_access_logs): pointing two sources at the same bucket creates two EventBridge rules and double-invokes the collector Lambda per object."
+    }
+  }
+}
+
+# PREREQUISITE: EventBridge notifications must already be enabled on each bucket
+# (bucket Properties -> Amazon EventBridge, or eventbridge = true in the stack
+# that owns the bucket's notification configuration). The module deliberately
+# does not manage the buckets' notification configuration: it is a single
+# replace-all document, and overwriting it would destroy any existing
+# SQS/SNS/Lambda notifications on these customer-owned buckets.
+resource "aws_cloudwatch_event_rule" "collection_bucket_trigger" {
+  for_each    = local.collection_buckets
+  name        = coalesce(each.value.rule_name, "streamsec-${each.key}-s3-${substr(md5(each.value.bucket_name), 0, 8)}-rule")
+  description = each.value.rule_description
+  event_pattern = jsonencode({
+    source      = ["aws.s3"],
+    detail-type = ["Object Created"],
+    detail = merge(
+      {
+        bucket = {
+          name = [each.value.bucket_name]
+        }
+      },
+      each.value.key_prefix != null ? {
+        object = {
+          key = [{ prefix = each.value.key_prefix }]
+        }
+      } : {}
+    )
+  })
+
+  tags = var.tags
+
+  lifecycle {
+    precondition {
+      condition     = data.aws_s3_bucket.collection_bucket[each.key].bucket_region == data.aws_region.current.region
+      error_message = "Collection buckets must be in the same region as this module's provider: S3 emits EventBridge events in the bucket's region, so a cross-region rule would never fire."
+    }
+  }
+}
+
+resource "aws_cloudwatch_event_target" "collection_bucket_target" {
+  for_each = local.collection_buckets
+  rule     = aws_cloudwatch_event_rule.collection_bucket_trigger[each.key].name
+  arn      = aws_lambda_function.streamsec_iam_activity_lambda.arn
+
+  depends_on = [aws_lambda_permission.collection_bucket_allow_invoke]
+}
+
+resource "aws_lambda_permission" "collection_bucket_allow_invoke" {
+  for_each      = local.collection_buckets
+  statement_id  = "AllowInvocationFromEventBridge-${each.key}"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.streamsec_iam_activity_lambda.arn
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.collection_bucket_trigger[each.key].arn
 }

--- a/modules/iam-activity/main.tf
+++ b/modules/iam-activity/main.tf
@@ -15,6 +15,10 @@ locals {
   # Additional EXISTING buckets whose new objects are forwarded to the collector
   # Lambda via EventBridge. Each entry becomes a rule/target/permission set and
   # an s3:GetObject grant (scoped to key_prefix when provided).
+  # NOTE: every source is declared here even when its bucket_name is null; the
+  # collection_buckets local below filters those out. Always consume
+  # collection_buckets (not collection_bucket_sources) so disabled sources are
+  # never processed.
   collection_bucket_sources = {
     apigateway = {
       bucket_name      = var.apigateway_bucket_name
@@ -23,14 +27,14 @@ locals {
       rule_name        = var.apigateway_s3_eventbridge_rule_name
       rule_description = var.apigateway_s3_eventbridge_rule_description
     }
-    s3-access-logs = {
+    s3_access_logs = {
       bucket_name      = var.s3_access_logs_bucket_name
       key_prefix       = var.s3_access_logs_key_prefix
       kms_key_arn      = var.s3_access_logs_kms_key_arn
       rule_name        = null
       rule_description = "Stream Security S3 Access Logs S3 EventBridge Rule"
     }
-    alb-access-logs = {
+    alb_access_logs = {
       bucket_name      = var.alb_access_logs_bucket_name
       key_prefix       = var.alb_access_logs_key_prefix
       kms_key_arn      = var.alb_access_logs_kms_key_arn
@@ -39,6 +43,7 @@ locals {
     }
   }
 
+  # Drop sources whose bucket_name is null (feature not enabled for that type).
   collection_buckets = { for k, v in local.collection_bucket_sources : k => v if v.bucket_name != null }
 
   collection_kms_key_arns = distinct([for v in values(local.collection_buckets) : v.kms_key_arn if v.kms_key_arn != null])
@@ -291,7 +296,7 @@ data "aws_s3_bucket" "collection_bucket" {
     }
     precondition {
       condition     = length([for v in values(local.collection_buckets) : v.bucket_name if v.bucket_name == each.value.bucket_name]) == 1
-      error_message = "Each collection bucket name must be used by only one source (apigateway / s3_access_logs / alb_access_logs): pointing two sources at the same bucket creates two EventBridge rules and double-invokes the collector Lambda per object."
+      error_message = "Each collection bucket name must be used by only one source (apigateway / s3_access_logs / alb_access_logs). Two sources on the same bucket create two EventBridge rules whose object-key patterns can overlap, double-invoking the collector Lambda for the same object."
     }
   }
 }

--- a/modules/iam-activity/variables.tf
+++ b/modules/iam-activity/variables.tf
@@ -183,6 +183,102 @@ variable "iam_activity_s3_eventbridge_rule_description" {
 }
 
 ################################################################################
+# API Gateway Access Logs S3 (existing bucket)
+################################################################################
+
+variable "apigateway_bucket_name" {
+  description = "(Optional) Name of an EXISTING S3 bucket (in the same region as this module's provider) that already receives API Gateway access logs (e.g. delivered via Kinesis Data Firehose). PREREQUISITE: EventBridge notifications must be enabled on the bucket, see: https://docs.streamsec.io/docs/configure-s3-event-notifications-with-amazon-eventbridge. When set, the module creates an EventBridge rule that forwards new objects to the collector Lambda. The bucket is NOT created or modified by this module. Must be a static string known at plan time, and must differ from iam_activity_bucket_name."
+  type        = string
+  default     = null
+  validation {
+    condition     = var.apigateway_bucket_name == null || can(regex("^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$", var.apigateway_bucket_name))
+    error_message = "apigateway_bucket_name must be a valid S3 bucket name (3-63 chars, lowercase letters, numbers, dots, hyphens)."
+  }
+}
+
+variable "apigateway_log_format" {
+  description = "The API Gateway access log format string configured on the API stage (JSON or delimited $context.* format). REQUIRED when apigateway_bucket_name is set — the collector uses it to parse the log lines and ignores API Gateway objects without it."
+  type        = string
+  default     = null
+}
+
+variable "apigateway_s3_key_prefix" {
+  description = "(Optional) S3 key prefix of the API Gateway access log objects (e.g. the Firehose delivery prefix). When set, the EventBridge rule only matches objects under this prefix, the Lambda's s3:GetObject permission is scoped to it, and the collector filters object keys by it."
+  type        = string
+  default     = null
+}
+
+variable "apigateway_kms_key_arn" {
+  description = "(Optional) ARN of the KMS key used to encrypt objects in the API Gateway bucket (SSE-KMS). When set, the Lambda execution role is granted kms:Decrypt on this key."
+  type        = string
+  default     = null
+}
+
+variable "apigateway_s3_eventbridge_rule_name" {
+  description = "The name of the EventBridge rule to create for the API Gateway access logs S3 bucket. Defaults to a unique name derived from the bucket name."
+  type        = string
+  default     = null
+}
+
+variable "apigateway_s3_eventbridge_rule_description" {
+  description = "The description of the EventBridge rule to create for the API Gateway access logs S3 bucket"
+  type        = string
+  default     = "Stream Security API Gateway Access Logs S3 EventBridge Rule"
+}
+
+################################################################################
+# S3 Access Logs S3 (existing bucket)
+################################################################################
+
+variable "s3_access_logs_bucket_name" {
+  description = "(Optional) Name of an EXISTING S3 bucket (in the same region as this module's provider) that is the target of S3 server access logging. PREREQUISITE: EventBridge notifications must be enabled on the bucket, see: https://docs.streamsec.io/docs/configure-s3-event-notifications-with-amazon-eventbridge. When set, the module creates an EventBridge rule that forwards new objects to the collector Lambda. The bucket is NOT created or modified by this module. Must be a static string known at plan time, and must differ from iam_activity_bucket_name."
+  type        = string
+  default     = null
+  validation {
+    condition     = var.s3_access_logs_bucket_name == null || can(regex("^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$", var.s3_access_logs_bucket_name))
+    error_message = "s3_access_logs_bucket_name must be a valid S3 bucket name (3-63 chars, lowercase letters, numbers, dots, hyphens)."
+  }
+}
+
+variable "s3_access_logs_key_prefix" {
+  description = "(Optional) S3 key prefix of the S3 access log objects (the target prefix configured on server access logging). When set, the EventBridge rule only matches objects under this prefix and the Lambda's s3:GetObject permission is scoped to it."
+  type        = string
+  default     = null
+}
+
+variable "s3_access_logs_kms_key_arn" {
+  description = "(Optional) ARN of the KMS key used to encrypt objects in the S3 access logs bucket (SSE-KMS). When set, the Lambda execution role is granted kms:Decrypt on this key."
+  type        = string
+  default     = null
+}
+
+################################################################################
+# ALB Access Logs S3 (existing bucket)
+################################################################################
+
+variable "alb_access_logs_bucket_name" {
+  description = "(Optional) Name of an EXISTING S3 bucket (in the same region as this module's provider) that is the target of ALB/ELB access logging. PREREQUISITE: EventBridge notifications must be enabled on the bucket, see: https://docs.streamsec.io/docs/configure-s3-event-notifications-with-amazon-eventbridge. When set, the module creates an EventBridge rule that forwards new objects to the collector Lambda. The bucket is NOT created or modified by this module. Must be a static string known at plan time, and must differ from iam_activity_bucket_name."
+  type        = string
+  default     = null
+  validation {
+    condition     = var.alb_access_logs_bucket_name == null || can(regex("^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$", var.alb_access_logs_bucket_name))
+    error_message = "alb_access_logs_bucket_name must be a valid S3 bucket name (3-63 chars, lowercase letters, numbers, dots, hyphens)."
+  }
+}
+
+variable "alb_access_logs_key_prefix" {
+  description = "(Optional) S3 key prefix of the ALB access log objects (the prefix configured on the load balancer's access_logs attribute). When set, the EventBridge rule only matches objects under this prefix and the Lambda's s3:GetObject permission is scoped to it."
+  type        = string
+  default     = null
+}
+
+variable "alb_access_logs_kms_key_arn" {
+  description = "(Optional) ARN of the KMS key used to encrypt objects in the ALB access logs bucket (SSE-KMS). When set, the Lambda execution role is granted kms:Decrypt on this key."
+  type        = string
+  default     = null
+}
+
+################################################################################
 # General
 ################################################################################
 

--- a/modules/iam-activity/versions.tf
+++ b/modules/iam-activity/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.2" # lifecycle preconditions
 
   required_providers {
     streamsec = {

--- a/modules/real-time-events/README.md
+++ b/modules/real-time-events/README.md
@@ -4,7 +4,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
 | <a name="requirement_streamsec"></a> [streamsec](#requirement\_streamsec) | >= 1.7 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.11 |
@@ -13,9 +13,9 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
-| <a name="provider_streamsec"></a> [streamsec](#provider\_streamsec) | >= 1.7 |
-| <a name="provider_time"></a> [time](#provider\_time) | >= 0.11 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_streamsec"></a> [streamsec](#provider\_streamsec) | 1.13.3 |
+| <a name="provider_time"></a> [time](#provider\_time) | 0.14.0 |
 
 ## Modules
 

--- a/modules/real-time-events/README.md
+++ b/modules/real-time-events/README.md
@@ -13,9 +13,9 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
-| <a name="provider_streamsec"></a> [streamsec](#provider\_streamsec) | 1.13.3 |
-| <a name="provider_time"></a> [time](#provider\_time) | 0.14.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
+| <a name="provider_streamsec"></a> [streamsec](#provider\_streamsec) | >= 1.7 |
+| <a name="provider_time"></a> [time](#provider\_time) | >= 0.11 |
 
 ## Modules
 

--- a/modules/real-time-events/README.md
+++ b/modules/real-time-events/README.md
@@ -3,42 +3,50 @@
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
 | <a name="requirement_streamsec"></a> [streamsec](#requirement\_streamsec) | >= 1.7 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.11 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
 | <a name="provider_streamsec"></a> [streamsec](#provider\_streamsec) | >= 1.7 |
+| <a name="provider_time"></a> [time](#provider\_time) | >= 0.11 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_privatelink"></a> [privatelink](#module\_privatelink) | ../private-link | n/a |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_cloudwatch_event_rule.streamsec_cloudwatch_rules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_target.streamsec_lambda_cloudwatch_target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_log_subscription_filter.streamsec_central_log_filters](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_subscription_filter) | resource |
+| [aws_iam_policy.kinesis_read_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.lambda_exec_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.lambda_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.kinesis_read_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.lambda_basic_execution_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.lambda_exec_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.lambda_vpc_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_lambda_event_source_mapping.kinesis_to_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_event_source_mapping) | resource |
 | [aws_lambda_function.streamsec_real_time_events_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_function_event_invoke_config.streamsec_options_cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function_event_invoke_config) | resource |
 | [aws_lambda_layer_version.streamsec_lambda_layer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_layer_version) | resource |
+| [aws_lambda_permission.streamsec_allow_cwlogs_invocation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_lambda_permission.streamsec_allow_lambda_cloudwatch_invocation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_secretsmanager_secret.streamsec_collection_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret_version.streamsec_collection_secret_version](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [streamsec_aws_real_time_events_ack.this](https://registry.terraform.io/providers/streamsec-terraform/streamsec/latest/docs/resources/aws_real_time_events_ack) | resource |
+| [time_sleep.wait_for_rules](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [streamsec_aws_account.this](https://registry.terraform.io/providers/streamsec-terraform/streamsec/latest/docs/data-sources/aws_account) | data source |
@@ -47,7 +55,19 @@
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_central_apigateway_log_format"></a> [central\_apigateway\_log\_format](#input\_central\_apigateway\_log\_format) | The API Gateway access log format string configured on the API stage(s) feeding central\_apigateway\_log\_groups / central\_kinesis\_stream\_arns. REQUIRED for the collector to parse those logs; without it API Gateway log lines are skipped. | `string` | `null` | no |
+| <a name="input_central_apigateway_log_groups"></a> [central\_apigateway\_log\_groups](#input\_central\_apigateway\_log\_groups) | (Optional) List of existing CloudWatch Logs log groups containing API Gateway access logs (REST, HTTP, or WebSocket APIs) | `list(string)` | `[]` | no |
+| <a name="input_central_bedrock_log_groups"></a> [central\_bedrock\_log\_groups](#input\_central\_bedrock\_log\_groups) | (Optional) List of existing CloudWatch Logs log groups containing Bedrock model invocation logs | `list(string)` | `[]` | no |
+| <a name="input_central_cloudtrail_log_groups"></a> [central\_cloudtrail\_log\_groups](#input\_central\_cloudtrail\_log\_groups) | (Optional) List of existing CloudWatch Logs log groups containing CloudTrail logs | `list(string)` | `[]` | no |
+| <a name="input_central_eks_audit_log_groups"></a> [central\_eks\_audit\_log\_groups](#input\_central\_eks\_audit\_log\_groups) | (Optional) List of existing CloudWatch Logs log groups containing EKS audit logs | `list(string)` | `[]` | no |
+| <a name="input_central_kinesis_batch_size"></a> [central\_kinesis\_batch\_size](#input\_central\_kinesis\_batch\_size) | Max records per Lambda invocation from Kinesis | `number` | `200` | no |
+| <a name="input_central_kinesis_batch_window"></a> [central\_kinesis\_batch\_window](#input\_central\_kinesis\_batch\_window) | Max seconds to buffer Kinesis records before invoking Lambda | `number` | `60` | no |
+| <a name="input_central_kinesis_memory_size"></a> [central\_kinesis\_memory\_size](#input\_central\_kinesis\_memory\_size) | Memory in MB for the Lambda function when consuming from Kinesis | `number` | `512` | no |
+| <a name="input_central_kinesis_stream_arns"></a> [central\_kinesis\_stream\_arns](#input\_central\_kinesis\_stream\_arns) | (Optional) List of Kinesis Data Stream ARNs receiving CloudWatch Logs | `list(string)` | `[]` | no |
+| <a name="input_central_route53_log_groups"></a> [central\_route53\_log\_groups](#input\_central\_route53\_log\_groups) | (Optional) List of existing CloudWatch Logs log groups containing Route53 DNS query logs | `list(string)` | `[]` | no |
+| <a name="input_central_vpc_flow_logs_fields"></a> [central\_vpc\_flow\_logs\_fields](#input\_central\_vpc\_flow\_logs\_fields) | (Optional) Space-separated flow log field names. Empty = default 14-field format | `string` | `""` | no |
+| <a name="input_central_vpc_flow_logs_log_groups"></a> [central\_vpc\_flow\_logs\_log\_groups](#input\_central\_vpc\_flow\_logs\_log\_groups) | (Optional) List of existing CloudWatch Logs log groups containing VPC Flow Logs | `list(string)` | `[]` | no |
 | <a name="input_cloudwatch_event_rules_prefix"></a> [cloudwatch\_event\_rules\_prefix](#input\_cloudwatch\_event\_rules\_prefix) | Prefix to use for the CloudWatch event rules | `string` | `"streamsec-"` | no |
 | <a name="input_enable_privatelink"></a> [enable\_privatelink](#input\_enable\_privatelink) | Create an Interface VPC Endpoint for StreamSecurity | `bool` | `false` | no |
 | <a name="input_enable_privatelink_private_dns"></a> [enable\_privatelink\_private\_dns](#input\_enable\_privatelink\_private\_dns) | Enable Private DNS on the VPC Endpoint (recommended) | `bool` | `true` | no |
@@ -55,7 +75,7 @@
 | <a name="input_lambda_cloudwatch_max_event_age"></a> [lambda\_cloudwatch\_max\_event\_age](#input\_lambda\_cloudwatch\_max\_event\_age) | The maximum age of a request that Lambda sends to a function for processing, in seconds | `number` | `21600` | no |
 | <a name="input_lambda_cloudwatch_max_retry"></a> [lambda\_cloudwatch\_max\_retry](#input\_lambda\_cloudwatch\_max\_retry) | The maximum number of times to retry when the function returns an error | `number` | `2` | no |
 | <a name="input_lambda_cloudwatch_memory_size"></a> [lambda\_cloudwatch\_memory\_size](#input\_lambda\_cloudwatch\_memory\_size) | The amount of memory in MB to allocate to the lambda function | `number` | `256` | no |
-| <a name="input_lambda_cloudwatch_s3_source_code_key"></a> [lambda\_cloudwatch\_s3\_source\_code\_key](#input\_lambda\_cloudwatch\_s3\_source\_code\_key) | The S3 key for the lambda source code | `string` | `"9cf1709dd6146fb541e090981f983c1d"` | no |
+| <a name="input_lambda_cloudwatch_s3_source_code_key"></a> [lambda\_cloudwatch\_s3\_source\_code\_key](#input\_lambda\_cloudwatch\_s3\_source\_code\_key) | The S3 key for the lambda source code | `string` | `"4a752d836232381fc3c72ac51458c1bc"` | no |
 | <a name="input_lambda_cloudwatch_timeout"></a> [lambda\_cloudwatch\_timeout](#input\_lambda\_cloudwatch\_timeout) | The amount of time in seconds the lambda function is allowed to run | `number` | `60` | no |
 | <a name="input_lambda_collection_secret_name"></a> [lambda\_collection\_secret\_name](#input\_lambda\_collection\_secret\_name) | The name of the secret to use for the lambda function | `string` | `"streamsec-collection-token"` | no |
 | <a name="input_lambda_iam_role_description"></a> [lambda\_iam\_role\_description](#input\_lambda\_iam\_role\_description) | Description to use on IAM role created | `string` | `"Stream Security IAM Role"` | no |
@@ -64,7 +84,7 @@
 | <a name="input_lambda_iam_role_tags"></a> [lambda\_iam\_role\_tags](#input\_lambda\_iam\_role\_tags) | A map of additional tags to add to the IAM role created | `map(string)` | `{}` | no |
 | <a name="input_lambda_iam_role_use_name_prefix"></a> [lambda\_iam\_role\_use\_name\_prefix](#input\_lambda\_iam\_role\_use\_name\_prefix) | Determines whether the IAM role name (`iam_role_name`) is used as a prefix | `bool` | `true` | no |
 | <a name="input_lambda_layer_name"></a> [lambda\_layer\_name](#input\_lambda\_layer\_name) | The name of the lambda layer | `string` | `"streamsec-real-time-events-layer"` | no |
-| <a name="input_lambda_layer_s3_source_code_key"></a> [lambda\_layer\_s3\_source\_code\_key](#input\_lambda\_layer\_s3\_source\_code\_key) | The S3 key for the lambda source code | `string` | `"98919b98292d9b3ec577cb43bd280a2a"` | no |
+| <a name="input_lambda_layer_s3_source_code_key"></a> [lambda\_layer\_s3\_source\_code\_key](#input\_lambda\_layer\_s3\_source\_code\_key) | The S3 key for the lambda source code | `string` | `"1e8d00c5c5513f60c336658713ee2cd5"` | no |
 | <a name="input_lambda_name"></a> [lambda\_name](#input\_lambda\_name) | Name of the lambda function | `string` | `"streamsec-real-time-events-lambda"` | no |
 | <a name="input_lambda_policy_description"></a> [lambda\_policy\_description](#input\_lambda\_policy\_description) | Description to use on IAM policy created | `string` | `"Stream Security IAM Policy for real time events lambda"` | no |
 | <a name="input_lambda_policy_name"></a> [lambda\_policy\_name](#input\_lambda\_policy\_name) | Name to use on IAM policy created | `string` | `"streamsec-events-lambda-policy"` | no |

--- a/modules/real-time-events/main.tf
+++ b/modules/real-time-events/main.tf
@@ -140,6 +140,11 @@ resource "aws_lambda_function" "streamsec_real_time_events_lambda" {
   tags = merge(var.tags, var.lambda_tags)
 
   lifecycle {
+    # Only the central_apigateway_log_groups path can be enforced here. The
+    # Kinesis path (central_kinesis_stream_arns) is a generic carrier that may
+    # deliver any log type, so we cannot require the API Gateway format whenever
+    # Kinesis is used without breaking non-API-Gateway Kinesis deployments. For
+    # the Kinesis path the format requirement is documented on the variable.
     precondition {
       condition     = length(var.central_apigateway_log_groups) == 0 || var.central_apigateway_log_format != null
       error_message = "central_apigateway_log_format is required when central_apigateway_log_groups is set: without it the collector cannot parse API Gateway access logs and silently drops them."

--- a/modules/real-time-events/main.tf
+++ b/modules/real-time-events/main.tf
@@ -130,11 +130,21 @@ resource "aws_lambda_function" "streamsec_real_time_events_lambda" {
         ENV         = "production"
         NODE_ENV    = "production"
       },
-      var.central_vpc_flow_logs_fields != "" ? { DEFAULT_FLOW_LOG_FIELDS = var.central_vpc_flow_logs_fields } : {}
+      var.central_vpc_flow_logs_fields != "" ? { DEFAULT_FLOW_LOG_FIELDS = var.central_vpc_flow_logs_fields } : {},
+      # required for the collector to parse API Gateway access logs arriving via
+      # central_apigateway_log_groups (CloudWatch Logs) or central_kinesis_stream_arns
+      var.central_apigateway_log_format != null ? { API_GATEWAY_LOG_FORMAT = var.central_apigateway_log_format } : {}
     )
   }
 
   tags = merge(var.tags, var.lambda_tags)
+
+  lifecycle {
+    precondition {
+      condition     = length(var.central_apigateway_log_groups) == 0 || var.central_apigateway_log_format != null
+      error_message = "central_apigateway_log_format is required when central_apigateway_log_groups is set: without it the collector cannot parse API Gateway access logs and silently drops them."
+    }
+  }
 }
 
 resource "aws_lambda_function_event_invoke_config" "streamsec_options_cloudwatch" {
@@ -148,11 +158,11 @@ resource "aws_lambda_function_event_invoke_config" "streamsec_options_cloudwatch
 ################################################################################
 
 resource "aws_cloudwatch_event_rule" "streamsec_cloudwatch_rules" {
-  for_each       = local.cloudwatch_rules
-  name           = each.value["name"]
-  description    = each.value["description"]
-  event_pattern  = each.value["event_pattern"]
-  tags           = var.tags
+  for_each      = local.cloudwatch_rules
+  name          = each.value["name"]
+  description   = each.value["description"]
+  event_pattern = each.value["event_pattern"]
+  tags          = var.tags
 }
 
 # Allow time for EventBridge rules to propagate before creating targets
@@ -162,10 +172,10 @@ resource "time_sleep" "wait_for_rules" {
 }
 
 resource "aws_cloudwatch_event_target" "streamsec_lambda_cloudwatch_target" {
-  for_each       = local.cloudwatch_rules
-  rule           = aws_cloudwatch_event_rule.streamsec_cloudwatch_rules[each.key].name
-  target_id      = "CloudWatchToLambda"
-  arn            = aws_lambda_function.streamsec_real_time_events_lambda.arn
+  for_each  = local.cloudwatch_rules
+  rule      = aws_cloudwatch_event_rule.streamsec_cloudwatch_rules[each.key].name
+  target_id = "CloudWatchToLambda"
+  arn       = aws_lambda_function.streamsec_real_time_events_lambda.arn
 
   depends_on = [time_sleep.wait_for_rules]
 }
@@ -205,6 +215,7 @@ locals {
     eksaudit   = var.central_eks_audit_log_groups
     route53    = var.central_route53_log_groups
     bedrock    = var.central_bedrock_log_groups
+    apigateway = var.central_apigateway_log_groups
   }
 
   central_log_subscriptions = merge([
@@ -222,10 +233,10 @@ EOT
 }
 
 resource "aws_lambda_permission" "streamsec_allow_cwlogs_invocation" {
-  count         = length(local.central_log_subscriptions) > 0 ? 1 : 0
-  action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.streamsec_real_time_events_lambda.function_name
-  principal     = "logs.${data.aws_region.current.region}.amazonaws.com"
+  count          = length(local.central_log_subscriptions) > 0 ? 1 : 0
+  action         = "lambda:InvokeFunction"
+  function_name  = aws_lambda_function.streamsec_real_time_events_lambda.function_name
+  principal      = "logs.${data.aws_region.current.region}.amazonaws.com"
   source_account = data.aws_caller_identity.current.account_id
 }
 

--- a/modules/real-time-events/variables.tf
+++ b/modules/real-time-events/variables.tf
@@ -250,6 +250,18 @@ variable "central_bedrock_log_groups" {
   default     = []
 }
 
+variable "central_apigateway_log_groups" {
+  description = "(Optional) List of existing CloudWatch Logs log groups containing API Gateway access logs (REST, HTTP, or WebSocket APIs)"
+  type        = list(string)
+  default     = []
+}
+
+variable "central_apigateway_log_format" {
+  description = "The API Gateway access log format string configured on the API stage(s) feeding central_apigateway_log_groups / central_kinesis_stream_arns. REQUIRED for the collector to parse those logs; without it API Gateway log lines are skipped."
+  type        = string
+  default     = null
+}
+
 variable "central_kinesis_stream_arns" {
   description = "(Optional) List of Kinesis Data Stream ARNs receiving CloudWatch Logs"
   type        = list(string)

--- a/modules/real-time-events/versions.tf
+++ b/modules/real-time-events/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.2" # lifecycle preconditions
 
   required_providers {
     streamsec = {


### PR DESCRIPTION
Adds access-log collection for API Gateway, ALB, and S3 server access logs.

## real-time-events
- `central_apigateway_log_groups` — collect API Gateway access logs from existing CloudWatch Logs groups (subscription filter → collector).
- `central_apigateway_log_format` — the API stage access-log format the collector parses with; a precondition requires it when `central_apigateway_log_groups` is set (otherwise logs are silently skipped).

## iam-activity — S3-bucket collection (existing, customer-owned buckets via EventBridge)
- **API Gateway**: `apigateway_bucket_name`, `apigateway_log_format`, `apigateway_s3_key_prefix`, `apigateway_kms_key_arn`, optional rule name/description.
- **S3 server access logs**: `s3_access_logs_bucket_name`, `s3_access_logs_key_prefix`, `s3_access_logs_kms_key_arn`.
- **ALB access logs**: `alb_access_logs_bucket_name`, `alb_access_logs_key_prefix`, `alb_access_logs_kms_key_arn`.
- A single `for_each` over the connected buckets creates an EventBridge rule + target + Lambda permission, with `s3:GetObject` scoped to the key prefix (and `kms:Decrypt` added when a KMS key is provided).
- Guards (lifecycle preconditions): collection bucket must be in the provider region, must differ from `iam_activity_bucket_name`, and no two sources may point at the same bucket; `apigateway_log_format` required when the API Gateway bucket is set.

## Notes
- Buckets are existing/customer-owned — the module does **not** create or modify them; EventBridge notifications must be enabled on each bucket.
- `versions.tf` bumped to `>= 1.2` (lifecycle preconditions).
- Examples and terraform-docs READMEs updated.